### PR TITLE
진행중인 콘테스트 목록 페이지 MarkUp

### DIFF
--- a/src/main/resources/static/css/list/contest_list.css
+++ b/src/main/resources/static/css/list/contest_list.css
@@ -1,0 +1,243 @@
+@import url('https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css');
+
+:root
+{
+    --main-color : #c1c0ff;
+    --sub-color : #ECFCE4;
+    --color-black : #000;
+    --dark-gray : #757575;
+    --line-gray: #D9D9D9;
+    --color-white : #fff;
+    
+    --font-size-32 : 32px;
+    --font-size-24 : 24px;
+    --font-size-20 : 20px;
+    --font-size-16 : 16px;
+    --font-size-14 : 14px;
+    --font-size-12 : 12px;
+
+}
+
+
+/* @font-face {
+    font-family: 'goorm-sans-serif';
+    src: url('https://fastly.jsdelivr.net/gh/projectnoonnu/2408@1.0/goorm-sans-serif.woff2') format('woff2');
+    font-weight: 700;
+    font-style: normal;
+} */
+
+*
+{
+    font-family: 'NanumSquare';
+    /* font-family: 'goorm-sans-serif'; */
+}
+
+/* a 태그 색, 밑줄 삭제 */
+a
+{
+ color: var(--color-black);
+ text-decoration: none;
+}
+
+/* header 영역 */
+header
+{
+    height: 145px;
+}
+
+
+/* main 영역 */
+main
+{
+    display: flex;
+    justify-content: center;
+}
+
+.mainWrap
+{
+    width: 1200px;
+}
+
+.banner
+{
+    height: 100px;
+    background-color: var(--line-gray);
+    border-radius: 6px;
+}
+
+.listHead
+{
+    height: 198px;
+    display: flex;
+    align-items: center;
+    padding-left: 50px;
+}
+.headWrap
+{
+    font-size: var(--font-size-32);
+    line-height: 10px;
+}
+
+
+/* 공모전 외부 영역 */
+section
+{
+    /* display: flex; */
+    width: 100%;
+    padding: 0px 23px 0 23px;
+    box-sizing: border-box;
+}
+.listWrap
+{
+    /* display: block; */
+    margin-bottom: 90px;
+    /* width: 100%; */
+}
+
+/* 정렬 select box 영역 */
+.orderWrap
+{
+    display: flex;
+    justify-content: flex-end;
+    margin-bottom: 10px;
+}
+
+.orderType
+{
+    height: 30px;
+    width: 134px;
+    border-radius: 6px;
+    border: 1px solid var(--line-gray);
+    font-size: var(--font-size-14);
+    font-weight: 600;
+    padding: 5px 11px;
+    box-sizing: border-box;   
+}
+
+/* 공모전 리스트 영역 */
+.listValue
+{
+    width: 100%;
+    height: 115px;
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    margin-bottom: 15px;
+    &:hover
+    {
+        /* box-shadow: 0 5px 15px rgba(0,0,0,0.25); */
+        box-shadow: 0 5px 10px rgba(0,0,0,0.25);
+    }
+}
+
+.listArea
+{
+ width: 80%;
+ height: 100%;
+ border-right: 1px solid var(--line-gray); 
+ padding: 20px 40px;
+ box-sizing: border-box;
+}
+
+.listArea .content
+{
+    display: flex;
+    align-items: center;
+    font-size: var(--font-size-14);
+    gap: 15px;
+    margin-bottom: 7px;
+}
+
+.endDate
+{
+    background-color: var(--sub-color);
+    border-radius: 50px;
+    width: initial;
+    padding: 3px 7px;
+}
+
+.heart
+{
+    margin-left: auto;
+    font-size: 18px;
+    color: var(--line-gray);
+}
+
+.listArea h5
+{
+    font-size: var(--font-size-16);
+    font-weight: 900;
+    margin-bottom: 7px;
+    margin-top: 0;
+}
+
+.listArea .content.B
+{
+    gap: 20px;
+    margin-bottom: 0;
+}
+
+.content.B span
+{
+    margin-left: 5px;
+    color: var(--dark-gray);
+}
+
+.listChar
+{
+    /* display: flex; */
+    /* align-items: center; */
+    padding: 20px 40px;
+    box-sizing: border-box;
+    width: 20%;
+}
+
+.priceInfo
+{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: var(--font-size-14);
+    color: var(--dark-gray);
+    margin-bottom: 7px;
+
+}
+
+.infoArea
+{
+    display: flex;
+    align-items: center;
+    height: 10px;
+    font-size: var(--font-size-14);
+    /* gap: 10px; */
+}
+
+/* 아이콘과 텍스트 높이를 맞추기 위함 */
+.infoArea i
+{
+    font-size: 1.2em; /* 아이콘 크기 조정 */
+    margin-right: 10px; /* 텍스트와의 간격 조정 */
+}
+
+.host, .total
+{
+    font-size: 1em; /* 텍스트 크기 */
+    line-height: 1; /* 줄 높이 */
+}
+
+.priceInfo:last-child
+{
+    display: flex;
+    justify-content: flex-end;
+    font-size: var(--font-size-12);
+    margin-bottom: 0;
+}
+
+
+/* footer 영역 */
+footer
+{
+    height: 322px;
+    border-top: 1px solid var(--line-gray);
+}

--- a/src/main/resources/templates/list/contest_list.html
+++ b/src/main/resources/templates/list/contest_list.html
@@ -1,0 +1,598 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <!-- font-awesome include -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
+    <!-- bootstrap-icons include -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+    <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/css/line-awesome.min.css"> -->
+    <!-- <script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4=" crossorigin="anonymous"></script> -->
+    <script src="https://code.jquery.com/jquery-3.6.4.js" integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="../list/contest_list.css">
+</head>
+<body>
+    <header>
+
+    </header>
+    <main>
+        <div class="mainWrap">
+            <div class="banner">
+
+            </div>
+            <section>
+                <div class="listHead">
+                    <div class="headWrap">
+                        <h5>D'OH! 하고 놀랄만한 아이디어,</h5>
+                        <h5>콘테스트에 참여 해 보세요!</h5>
+                    </div>
+                </div><!--listHead-->
+                <div class="listWrap">
+                    <div class="orderWrap">
+                        <select name="orderType" id="" class="orderType">
+                            <option value="current" selected>최신등록순</option>
+                            <option value="latest">마감임박순</option>
+                            <option value="price">총 상금순</option>
+                            <option value="hit">조회순</option>
+                        </select>
+                    </div>
+                    <div class="contestWrap">
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+                        <a href="#">
+                            <div class="listValue">
+                                <div class="listArea">
+                                    <div class="content A">
+                                        <div class="endDate">8일 남음</div>
+                                        <div class="industry">식품/건강</div>
+                                        <div class="heart">
+                                            <i class="fa-solid fa-heart"></i>
+                                        </div>
+                                    </div>
+                                    <h5>글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                                    <div class="content B">
+                                        <div class="contestHost">헬스마켓</div>
+                                        <div class="hit">
+                                            <i class="bi bi-hand-index"></i>
+                                            <span>363</span>
+                                        </div>
+                                    </div>
+                                </div><!--listArea-->
+                                <div class="listChar">
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-trophy"></i>
+                                                </div>
+                                                <div class="host">총 상금</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total P"><span>30</span> 만원</div>
+                                    </div><!--상금 정보 부분-->
+                                    <div class="priceInfo">
+                                        <div class="infoArea">
+                                            <!-- <div class="infoLeft"> -->
+                                                <div>   
+                                                    <i class="bi bi-calendar-week"></i>
+                                                </div>
+                                                <div class="host">남은 기간</div>
+                                            <!-- </div> -->
+                                        </div>
+                                        <div class="total E"><span>8</span> 일</div>
+                                    </div><!--마감일 부분-->
+                                    <div class="priceInfo">
+                                        <div class="lastDate"><span>24.08.18</span> 마감</div>
+                                    </div>
+                                </div><!--listChar-->
+                            </div><!--listValue-->
+                        </a><!--콘테스트 정보-->
+
+                    </div><!--contestWrap-->
+                    <nav aria-label="Page navigation example">
+                        <ul class="pagination justify-content-center">
+                          <li class="page-item">
+                            <a class="page-link" href="#" aria-label="Previous">
+                              <span aria-hidden="true">&laquo;</span>
+                            </a>
+                          </li>
+                          <li class="page-item"><a class="page-link" href="#">1</a></li>
+                          <li class="page-item"><a class="page-link" href="#">2</a></li>
+                          <li class="page-item"><a class="page-link" href="#">3</a></li>
+                          <li class="page-item">
+                            <a class="page-link" href="#" aria-label="Next">
+                              <span aria-hidden="true">&raquo;</span>
+                            </a>
+                          </li>
+                        </ul>
+                      </nav>
+                </div><!--listWrap-->
+            </section><!--section-->
+        </div>
+    </main>
+    <footer>
+
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
헤더의 공모전 클릭시 이동되는 진행중인 콘테스트 목록 페이지 MarkUp 완료

구성 : 미니 배너 or 이미지 + 공모전 문구 + 정렬 기능 + 진행중인 콘테스트 목록(List 형식) + 페이징 기능

상세 :
1. 콘테스트 목록은 한 페이지에 10개만 출력되고 페이징 기능을 적용 예정
2. 정렬 기준 - 마감임박순, 최신순, 총 상금순, 조회순
3. 페이징 : 부트스트랩 디자인을 적용만 해 둔 상태라 색이나 디자인 통일 필요함.
![스크린샷 2024-09-04 115645](https://github.com/user-attachments/assets/0d8a5366-70c4-4dd4-914b-6d4771756b85)
![스크린샷 2024-09-04 115717](https://github.com/user-attachments/assets/dfd730b4-4f12-47ca-bb0a-5c3c554fa392)
