### PR TITLE
콘테스트 지원하기 버튼 클릭 후 약관 동의시 이동되는 페이지

### DIFF
--- a/src/main/resources/static/css/list/apply_2.css
+++ b/src/main/resources/static/css/list/apply_2.css
@@ -1,0 +1,243 @@
+@import url('https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css');
+
+:root
+{
+    --main-color : #c1c0ff;
+    --sub-color : #ECFCE4;
+    --color-black : #000;
+    --dark-gray : #757575;
+    --line-gray: #D9D9D9;
+    --color-white : #fff;
+    
+    --font-size-32 : 32px;
+    --font-size-24 : 24px;
+    --font-size-20 : 20px;
+    --font-size-16 : 16px;
+    --font-size-14 : 14px;
+
+}
+/* 전체 font 적용 */
+*
+{
+    font-family: 'NanumSquare';
+}
+
+/* header 영역 */
+header
+{
+    height: 145px;
+    border-bottom: 1px solid var(--line-gray);
+}
+
+/* main 영역 */
+main
+{
+    display: flex;
+    justify-content: center;
+}
+
+.mainWarap
+{
+    width: 1200px;
+}
+/* 콘테스트 정보 영역 */
+.contestWarap
+{
+    height: 114px;
+    width: 100%;
+    /* padding: 15px 35px 15px 35px; */
+    padding: 15px 0;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.day, .applyInfo
+{
+    display: flex;
+    align-items: center;
+    gap: 0 15px;
+}
+
+.day
+{
+    line-height: 10px;
+    font-size: var(--font-size-16);
+    margin-bottom: 10px;
+}
+.endDate
+{
+    background-color: var(--sub-color);
+    padding: 8px 15px;
+    border-radius: 50px;
+}
+
+.contitle
+{
+    font-size: var(--font-size-20);
+    font-weight: bold;
+    margin-bottom: 10px;
+}
+
+.info
+{
+    font-size: var(--font-size-16);
+}
+
+a
+{
+    color: var(--color-black);
+    text-decoration-line: none;
+}
+.briefing
+{
+    font-size: var(--font-size-20);
+    padding: 15px 20px;
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+}
+
+/* 지원 입력 내용 부분 */
+
+/* .applyWarap */
+section
+{
+ display: flex;
+ width: 100%;
+ gap: 30px;
+ /* margin-bottom: 90px; */
+ margin: 60px 0 90px 0;
+}
+
+.applyContent
+{
+    width: calc(80% - 15px);
+    /* border: 1px solid var(--line-gray); */
+}
+
+.applyWarap
+{
+    width: calc(20% - 15px);
+    /* border: 1px solid var(--line-gray); */
+}
+
+input[type="text"]
+{
+    width: 100%;
+    height: 50px;
+    padding: 15px 20px;
+    font-size: var(--font-size-16);
+    box-sizing: border-box;
+    border-radius: 6px;
+}
+
+.contArea
+{
+    margin-top: 40px;
+    width: 100%;
+    height: 770px;
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+}
+
+
+.applyInput
+{
+    width: 100%;
+    height: 130px;
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+    display: flex;
+}
+
+/* 사이드 */
+.InputArea
+{
+    width: 50%;
+    height: 100%;
+    border-right: 1px solid var(--line-gray);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    /* cursor: pointer; */
+}
+
+.InputArea:last-child
+{
+    border-right: none;
+}
+
+.content
+{
+    cursor: pointer;
+}
+
+.Image
+{
+    display: flex;
+    justify-content: center;
+    margin-bottom: 10px;
+}
+
+#image/*input 창 style 안 보이게 설정*/
+{
+    display: none;
+}
+
+.imageUpload/*해당 영역 선택시 파일 업로드 명시하도록 css 지정*/
+{
+    cursor: pointer;
+}
+.Image i
+{
+    font-size: 45px;
+}
+
+.inputText
+{
+    font-size: var(--font-size-14);
+}
+
+/* textarea css */
+textarea
+{
+    display: flex;
+    width: 100%;
+    padding: 10px 20px;
+    box-sizing: border-box;
+    font-size: var(--font-size-14);
+    resize: none;
+}
+
+button
+{
+    width: 100%;
+    height: 70px;
+    margin-top: 20px;
+    border-radius: 6px;
+    cursor: pointer;
+}
+
+.temporary
+{
+    background-color: var(--color-white);
+    border: 1px solid var(--line-gray);
+    font-size: var(--font-size-16);
+    /* font-weight: 600; */
+}
+
+.apply
+{
+    background-color: var(--color-black);
+    border: 1px solid var(--color-black);
+    color: var(--color-white);
+    font-size: var(--font-size-16);
+}
+
+
+/* footer 영역 */
+footer
+{
+    height: 322px;
+    border-top: 1px solid var(--line-gray);
+}

--- a/src/main/resources/static/js/list/apply_2.js
+++ b/src/main/resources/static/js/list/apply_2.js
@@ -1,0 +1,12 @@
+$(document).ready(function(){
+
+    $(".content.text").click(function () {
+        console.log("click!!");
+        var std ="<textarea name='' id='' placeholder='텍스트를 입력해주세요.'></textarea>";
+        // $(".contArea").appand(std); 오타
+        $(".contArea").append(std);
+    });//end of click function
+
+    
+
+});//end of document ready function

--- a/src/main/resources/templates/list/apply_2.html
+++ b/src/main/resources/templates/list/apply_2.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <!-- import font-awesome -->
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
+    <script src="https://code.jquery.com/jquery-3.6.4.js" integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script>
+    <script src="../js/list/apply_2.js"></script>
+    <link rel="stylesheet" href="../css/list/apply_2.css">
+</head>
+<body>
+    <header>
+
+    </header>
+    <main>
+        <div class="mainWarap">
+            <div class="contestWarap">
+                <div class="contestInfo">
+                    <div class="day">
+                        <div class="endDate info">8일</div>
+                        <div class="type info">공공 기관</div>
+                    </div>
+                    <div class="contitle">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>
+                    <div class="applyInfo">
+                        <div class="info">총 상금 300만원</div>
+                        <div class="info">참여작 <span>9</span>개</div>
+                    </div>
+                </div><!--contestInfo-->
+                <a href="#">
+                    <div class="briefing">브리핑 확인하기</div>
+                </a>
+            </div><!--contestWarap-->
+            
+            
+            <section>
+                <div class="applyContent">
+                    <input type="text" placeholder="제목을 입력해주세요.">
+                    <div class="contArea">
+
+                    </div>
+                </div>
+                <!-- </section> -->
+                <!-- <section> -->
+                <div class="applyWarap">
+                    <div div class="applyInput">
+                        <div class="InputArea">
+                            <label for="image" class="imageUpload">
+                                <div class="content">
+                                    <span class="Image">
+                                        <i class="fa-regular fa-image"></i>
+                                    </span>
+                                    <div class="inputText">이미지 추가</div>
+                                </div>
+                            </label>
+                            <input type="file" name="" id="image" multiple>
+                        </div>
+                        <div class="InputArea">
+                            <div class="content text">
+                                <span class="Image">
+                                    <i class="fa-regular fa-pen-to-square"></i>
+                                </span>
+                                <div class="inputText">텍스트 추가</div>
+                            </div>
+                        </div>
+                    </div><!--applyInput-->
+                    <button type="button" class="temporary">
+                      임시 저장  
+                    </button>
+                    <button type="submit" class="apply">
+                      지원하기  
+                    </button>
+                </div><!--applyWarap-->
+            </section>
+        </div>
+    </main>
+    <footer>
+
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
콘테스트 지원하기 버튼 클릭하면 이동되는 약관 동의 페이지(apply_1)에서 약관 동의시 이동되는 페이지
구성 : 지원 제목, 내용 입력(text, images), 임시저장, 제출
figma 디자인을 기반으로 markup 하여 지원 내용을 입력, 지원할 수 있도록 구현

* 상단의 내용은 지원을 선택한 콘테스트의 정보를 간략히 보여줌
* 브리핑 확인하기 버튼 클릭시 해당 콘테스트 정보 페이지로 이동 예정
* 이미지 업로드 클릭시 이미지 선택 까지는 뜨나 저장소가 정해져 있지 않아 출력 기능까지는 적용되지 않음

![스크린샷 2024-09-04 152218](https://github.com/user-attachments/assets/acc140ac-9b33-402b-a8d4-af9500fcafdd)
