### PR TITLE
지원자 지원 내역 상세 페이지 MarkUp

### DIFF
--- a/src/main/resources/static/css/list/applyInfDetail.css
+++ b/src/main/resources/static/css/list/applyInfDetail.css
@@ -1,0 +1,203 @@
+@import url('https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css');
+
+:root
+{
+    --main-color : #c1c0ff;
+    --sub-color : #ECFCE4;
+    --color-black : #000;
+    --dark-gray : #757575;
+    --line-gray: #D9D9D9;
+    --color-white : #fff;
+    
+    --font-size-32 : 32px;
+    --font-size-24 : 24px;
+    --font-size-20 : 20px;
+    --font-size-16 : 16px;
+    --font-size-14 : 14px;
+
+}
+
+*
+{
+    font-family: 'NanumSquare';
+}
+
+/* header 영역 */
+header
+{
+    height: 145px;
+}
+
+/* main 영역 */
+main
+{
+    display: block;
+}
+
+.banner
+{
+    width: 100%;
+    min-height: 292px;
+    background-color: var(--dark-gray);
+    position: relative;
+
+}
+
+/* banner 하위 영역에 대한 전체적인 틀을 잡아중 */
+section
+{
+    display: flex;
+    justify-content: center;
+    position: relative;
+    top: -25vh;
+}
+
+.mainWrap
+{
+    width: 1200px;
+    display: flex;
+    justify-content: space-between;
+    gap: 30px;
+    margin-bottom: 90px;
+    
+}
+
+/* applyWrap 영역 */
+.applyWrap
+{
+    width: calc(70% - 15px);
+    /* border: 1px solid var(--dark-gray); */
+}
+
+.applyMain
+{
+    width: 100%;
+    height: 480px;
+    background-color: var(--line-gray);
+    border-radius: 6px;
+    border: 1px solid var(--line-gray);
+}
+
+.applyWrap h5
+{
+    font-size: var(--font-size-20);
+    font-weight: 900;
+    /* margin-top: 40px; */
+    margin: 50px 0 20px 0;
+}
+
+.applyTitle
+{
+    border-bottom: 1px solid var(--line-gray);
+}
+
+/* sectionInfo 영역 */
+.sectionInfo
+{
+    width: calc(30% - 15px);
+    display: block;
+}
+
+.infoArea
+{
+    margin: 20px 0 40px 0;
+}
+
+.infoArea .info
+{
+    font-size: var(--font-size-24);
+    font-weight: 800;
+    color: var(--color-white);
+}
+
+.info.id
+{
+    margin-top: 10px;
+    font-size: var(--font-size-16);
+}
+
+/* boxSection */
+.boxWrap
+{
+    width: 100%;
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+    background-color: var(--color-white);
+    padding: 20px;
+    box-sizing: border-box;   
+    margin-bottom: 15px;
+
+    &:last-child
+    {
+        margin-bottom: 0;
+    }
+    &.active
+    {
+        border: 2px solid var(--main-color);
+    }
+}
+
+.boxWrap .box
+{
+    display: flex;
+    align-items: center;
+}
+
+.box .boxContent
+{
+    display: flex;
+    justify-content: space-between;
+    width: 100%;
+
+}
+
+.trophyArea
+{
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    line-height: 5px;
+}
+
+.choosePeople
+{
+    font-size: var(--font-size-14);
+    margin-left: 20px;
+    color: var(--dark-gray);
+}
+
+.buttonWrap
+{
+    display: flex;
+    justify-content: center;
+    margin-top: 10px;
+    /* margin-bottom: 20px; */
+}
+
+.boxWrap button
+{
+    width: 80%;
+    background-color: var(--line-gray);
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+    padding: 5px 0 5px 0;
+    display: none;
+    &:hover
+    {
+        background-color: var(--main-color);
+        border: 1px solid var(--main-color);
+    }
+    &.active
+    {
+        background-color: var(--main-color);
+        border: 1px solid var(--main-color);
+    }
+}
+
+
+/* footer 영역 */
+footer
+{
+    height: 322px;
+    border-top: 1px solid var(--line-gray);
+}

--- a/src/main/resources/static/js/list/applyInfDetail.js
+++ b/src/main/resources/static/js/list/applyInfDetail.js
@@ -1,0 +1,26 @@
+$(document).ready(function(){
+
+        $('.boxWrap').click(function(){
+            var button = $(this).find('.buttonWrap button');
+            if(button.is(':visible')) {
+                button.slideUp();
+                $(this).removeClass('active');
+            } else {
+                $('.boxWrap .buttonWrap button').slideUp();
+                $('.boxWrap').removeClass('active');
+                button.slideDown();
+                $(this).addClass('active');
+            }
+        });
+
+          // 수상작 버튼 클릭 시 전파 막기
+          $('.buttonWrap button').click(function(event){
+            event.stopPropagation();
+            var result = confirm("수상작으로 선정하시겠습니까?")
+            if(result){
+            alert("수상작으로 선정하였습니다!"); // 수상작 선정 후 동작 예시
+            $(this).addClass("active");
+            }
+        });
+    // });
+});//end of document ready

--- a/src/main/resources/templates/list/applyInfDetail.html
+++ b/src/main/resources/templates/list/applyInfDetail.html
@@ -1,0 +1,143 @@
+<!DOCTYPE html>
+<html lang="en"  xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+        <!-- font-awesome include -->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
+        <!-- bootstrap-icons include -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+        <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/css/line-awesome.min.css"> -->
+        <!-- <script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4=" crossorigin="anonymous"></script> -->
+        <script src="https://code.jquery.com/jquery-3.6.4.js" integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script>
+
+    <!-- 기존 방식 : <link rel="stylesheet" href="applyinfo_detail.css">-->
+    <!--    thymeleaf를 이용한 CSS include-->
+    <link rel="stylesheet" th:href="@{/css/list/applyInfDetail.css}"/>
+    <link rel="stylesheet" th:href="@{/css/fragments/header.css}">
+    <link rel="stylesheet" th:href="@{/css/fragments/footer.css}">
+
+    <!--        <script src="applyinfo_detail.js"></script>-->
+    <!--    thymeleaf를 이용한 JS include-->
+    <script th:src="@{/js/list/applyInfDetail.js}"></script>
+</head>
+<body>
+<!--    <header>-->
+    <header th:replace="~{fragments/header :: headerFragment}">
+
+    </header>
+    <main>
+        <div class="banner"></div><!--banner-->
+
+        <section>
+            <div class="mainWrap">
+                <div class="applyWrap">
+                    <div class="applyMain">
+                    <!-- 지원 or 포토폴리오 첫번 째 이미지가 출력될 부분 -->
+                    </div><!--applyMain-->
+                    <div class="applyTitle">
+                        <h5>작품 설명</h5>
+                    </div>
+                    <div class="applyContet">
+                    <!--지원 or 포토폴리오 내용이 출력될 부분 -->
+                        <ul>
+                            <li></li><!--image가 출력될 영역-->
+                        </ul>
+                    </div><!--applyContet-->
+                </div><!--applyWrap-->
+
+                <div class="sectionInfo">
+                    <div class="infoArea">
+                        <div class="info">
+                            로고는 심플하고 강렬하게 기억되어야 합니다.
+                        </div>
+                        <div class="info id">아이줌디자인</div>
+                    </div>
+
+                    <div class="boxSection">
+                    <!-- <div class="box">
+                            <div class="boxContent">
+                                <div class="trophyArea">
+                                    <i class="fa-solid fa-medal"></i>
+                                    <div>1등</div>
+                                </div>
+                                <div class="awardPay">30만원</div>
+                            </div>
+                            <div class="buttonWrap">
+                                <button type="button">수상작으로 선정하기</button>
+                            </div>
+                        </div>box type_1 -->
+                        <!-- <div class="box">
+                            <div class="boxContent">
+                                <div class="trophyArea">
+                                    <i class="fa-solid fa-medal"></i>
+                                    <div>2등 <span>· 2</span>명</div>
+                                </div>
+                                <div class="awardPay">20만원</div>
+                            </div>
+                            <div class="buttonWrap">
+                                <button type="button">수상작으로 선정하기</button>
+                            </div>
+                        </div>box type_2 -->
+                        <div class="boxWrap">
+                            <div class="box">
+                                <div class="boxContent">
+                                    <div class="trophyArea">
+                                        <i class="fa-solid fa-medal"></i>
+                                        <div>1등</div>
+                                    </div>
+                                    <div class="awardPay">30만원</div>
+                                </div>
+                            </div><!--box-->
+                            <div class="choosePeople">선정 인원 : <span>1</span>명</div>
+
+                            <div class="buttonWrap">
+                                <button type="button">수상작으로 선정하기</button>
+                            </div>
+                        </div><!--boxWrap-->
+
+                        <div class="boxWrap">
+                            <div class="box">
+                                <div class="boxContent">
+                                    <div class="trophyArea">
+                                        <i class="fa-solid fa-medal"></i>
+                                        <div>2등</div>
+                                    </div>
+                                    <div class="awardPay">20만원</div>
+                                </div>
+                            </div><!--box-->
+                            <div class="choosePeople">선정 인원 : <span>2</span>명</div>
+
+                            <div class="buttonWrap">
+                                <button type="button">수상작으로 선정하기</button>
+                            </div>
+                        </div><!--boxWrap-->
+
+                        <div class="boxWrap">
+                            <div class="box">
+                                <div class="boxContent">
+                                    <div class="trophyArea">
+                                        <i class="fa-solid fa-medal"></i>
+                                        <div>3등</div>
+                                    </div>
+                                    <div class="awardPay">10만원</div>
+                                </div>
+                            </div><!--box-->
+                            <div class="choosePeople">선정 인원 : <span>3</span>명</div>
+
+                            <div class="buttonWrap">
+                                <button type="button">수상작으로 선정하기</button>
+                            </div>
+                        </div><!--boxWrap-->
+                    </div><!--boxSection-->
+                </div><!--sectionInfo-->
+            </div><!--mainWrap-->
+        </section>
+    </main>
+    <footer th:replace="~{fragments/footer :: footerFragment}">
+
+    </footer>
+</body>
+</html>

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -12,7 +12,7 @@
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/css/line-awesome.min.css"> -->
     <!-- <script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4=" crossorigin="anonymous"></script> -->
     <script src="https://code.jquery.com/jquery-3.6.4.js" integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script>
-    <link rel="stylesheet" href="../list/contest_list.css">
+    <link rel="stylesheet" href="../list/contestList.css">
 </head>
 <body>
     <header>

--- a/src/main/resources/templates/list/main.html
+++ b/src/main/resources/templates/list/main.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en"  xmlns:th="http://www.thymeleaf.org">
+<html lang="en" xmlns:th="http://www.thymeleaf.org">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -8,16 +8,18 @@
     <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/css/line-awesome.min.css"> -->
     <!-- <script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4=" crossorigin="anonymous"></script> -->
     <script src="https://code.jquery.com/jquery-3.6.4.js" integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script>
-<!--    <script src="main.js"></script>-->
-<!--    <link rel="stylesheet" href="main.css">-->
+    <!--  기존 방식 :  <link rel="stylesheet" href="main.css">-->
+    <!--    thymeleaf를 이용한 CSS include-->
     <link rel="stylesheet" th:href="@{/css/list/main.css}"/>
     <link rel="stylesheet" th:href="@{/css/fragments/header.css}">
     <link rel="stylesheet" th:href="@{/css/fragments/footer.css}">
+    <!--   기존 방식 : <script src="main.js"></script>-->
+    <!--    thymeleaf를 이용한 JS include-->
     <script th:src="@{/js/list/main.js}"></script>
 </head>
 <body>
 <!--    <header>-->
-<header th:insert="~{fragments/header :: headerFragment}">
+<header th:replace="~{fragments/header :: headerFragment}">
 
     </header>
     <main>
@@ -355,7 +357,7 @@
         </div>
     </main>
 <!--    <footer>-->
-<footer th:insert="~{fragments/footer :: footerFragment}">
+<footer th:replace="~{fragments/footer :: footerFragment}">
 
     </footer>
 </body>


### PR DESCRIPTION
콘테스트에 지원한 지원자의 지원 정보를 볼 수 있는 페이지 기본 MarkUp
(+ 추가로 다른 페이지의 th:insert -> th:replace로 교체)

페이지 정보 및 구현 내용 : 
1. backgroud color - dark gray로 고정
2. 지원 이미지 중 첫번 째를 대표 이미지로 선정 및 하단 영역에 내용 출력 예정
3. 우측에 지원 제목과 지원자명 출력
4. 1, 2, 3등 등수 및 금액, 인원 출력
5. 해당 box 클릭시 수상자 선정 버튼을 출력
6. 선정 완료시 해당 수상 정보 활성화 유지 처리

페이지 연결 :
1. 콘테스트 상세 정보 페이지에서 지원하기 버튼을 통해 콘테스트에 응모
7. 콘테스트 주최자가 마이페이지에서 진행한 콘테스트 목록 확인
8. 해당 콘테스트 클릭시 콘테스트 상세 정보 페이지로 연결
9. 탭으로 지원자의 지원 목록을 확인
10. 지원자를 선택시 해당 지원자의 지원 정보를 볼 수 있는 페이지로 연결  **← markUp 페이지**
11. 작품 확인 후 1, 2, 3등 등수 및 상금이 적힌 박스를 선택하면 silddown으로 수상작으로 선정할 수 있는 버튼이 출력됨
12. 버튼 클릭시 cofrim( ) 메소드로 수상자 선정 여부를 재확인
13. 확인을 누르면 수상작으로 선정됨