### PR TITLE
포토폴리오 상세 페이지 MarkUp

### DIFF
--- a/src/main/resources/static/css/user/portfolioDetail.css
+++ b/src/main/resources/static/css/user/portfolioDetail.css
@@ -1,0 +1,223 @@
+@import url('https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css');
+
+:root
+{
+    --main-color : #c1c0ff;
+    --sub-color : #ECFCE4;
+    --color-black : #000;
+    --dark-gray : #757575;
+    --line-gray: #D9D9D9;
+    --color-white : #fff;
+    
+    --font-size-32 : 32px;
+    --font-size-24 : 24px;
+    --font-size-20 : 20px;
+    --font-size-16 : 16px;
+    --font-size-14 : 14px;
+    --font-size-14 : 12px;
+
+}
+
+*
+{
+    font-family: 'NanumSquare';
+}
+
+/* header 영역 */
+header
+{
+    height: 145px;
+}
+
+/* main 영역 */
+main
+{
+    display: block;
+}
+
+.banner
+{
+    width: 100%;
+    min-height: 292px;
+    background-color: var(--dark-gray);
+    position: relative;
+
+}
+
+/* banner 하위 영역에 대한 전체적인 틀을 잡아중 */
+section
+{
+    display: flex;
+    justify-content: center;
+    position: relative;
+    top: -25vh;
+}
+
+.mainWrap
+{
+    width: 1200px;
+    display: flex;
+    justify-content: space-between;
+    gap: 30px;
+    margin-bottom: 90px;
+    
+}
+
+/* portfolioWrap 영역 */
+.portfolioWrap
+{
+    width: calc(70% - 15px);
+    /* border: 1px solid var(--dark-gray); */
+}
+
+.portfolioMain
+{
+    width: 100%;
+    height: 480px;
+    background-color: var(--line-gray);
+    border-radius: 6px;
+    border: 1px solid var(--line-gray);
+}
+
+.description .title
+{
+    margin: 40px 0 20px 0;
+    font-size: var(--font-size-20);
+    font-weight: 800;
+}
+
+.description h5
+{
+    font-size: var(--font-size-16);
+    font-weight: 900;
+    /* margin-top: 40px; */
+    margin-bottom: 20px;
+}
+
+.description
+{
+    border-bottom: 1px solid var(--line-gray);
+    /* display: flex; */
+    gap: 30px;
+}
+
+article
+{
+    margin-top: 20px;
+}
+
+article .content
+{
+    padding: 10px 15px 0 15px;
+    line-height: 1.6; /* 줄 간격 조정 */
+    white-space: pre-line; /* 줄바꿈과 연속 공백을 유지 */
+    font-size: var(--font-size-14);
+}
+
+article .title
+{
+    font-size: var(--font-size-16);
+    font-weight: 800;
+    padding: 0;
+}
+
+/* aside 영역 */
+aside
+{
+    width: calc(30% - 15px);
+    display: block;
+    /* margin-top: 40px; */
+    padding: 5px 15px;
+    background-color: var(--color-white);
+    border: 1px solid var(--color-white);
+    border-radius: 6px;
+}
+
+figure  .title
+{
+    margin: 40px 0 10px 0;
+    font-size: var(--font-size-20);
+    font-weight: 900;
+    border-bottom: none;
+}
+
+
+/* 디자이너 정보 영역 */
+.info
+{
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.user
+{
+    font-size: var(--font-size-16);
+    font-weight: 700;
+    &.more
+    {
+        cursor: pointer;
+    }
+}
+
+.profileInfo
+{
+    /* display: none; */
+    line-height: 1.6; /* 줄 간격 조정 */
+    white-space: pre-line; /* 줄바꿈과 연속 공백을 유지 */
+    font-size: var(--font-size-14);
+}
+
+/* 포토폴리오 목록 영역 */
+.cardList
+{
+    display: flex;
+    /* display: grid; */
+    /* grid-template-columns: 1fr 1fr 1fr 1fr 1fr; */
+    /* width: 100%; */
+    gap: 15px;
+    margin-top: 20px;
+}
+
+.cardList .list
+{
+    height: 57px;
+    width: 20%;
+    background-color: var(--line-gray);
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+    cursor: pointer;
+    &:last-of-type
+    {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+}
+
+
+/* 채팅 버튼 */
+/* aside button */
+button
+{
+    margin-top: 20px;
+    width: 100%;
+    padding: 10px 20px;
+    background: var(--line-gray);
+    border: 1px solid var(--line-gray);
+    border-radius: 6px;
+    font-size: var(--font-size-16);
+    &:hover
+    {
+        background-color: var(--main-color);
+        border-color: var(--main-color);
+    }
+}
+
+
+/* footer 영역 */
+footer
+{
+    height: 322px;
+    border-top: 1px solid var(--line-gray);
+}

--- a/src/main/resources/static/js/user/portfolioDetail.js
+++ b/src/main/resources/static/js/user/portfolioDetail.js
@@ -1,0 +1,18 @@
+
+$(document).ready(function(){
+    $(".user.more").click(function () {
+        var profileInfo = $(".profileInfo");
+        // var icon = $(".fa-angle-down, .fa-angle-up"); // 둘 다 선택
+        var icon = $(".fa-solid");
+        // $(".profileInfo").css({"display":"block"});
+
+        // 현재 display 상태에 따라 block 또는 none으로 토글
+        if (profileInfo.css("display") === "none") {
+            profileInfo.css("display", "block");
+            icon.removeClass("fa-angle-down").addClass("fa-angle-up");
+        } else {
+            profileInfo.css("display", "none");
+            icon.removeClass("fa-angle-up").addClass("fa-angle-down");
+        }
+    })
+});//end of document ready

--- a/src/main/resources/templates/user/portfolioDetail.html
+++ b/src/main/resources/templates/user/portfolioDetail.html
@@ -1,0 +1,107 @@
+<!DOCTYPE html>
+<html lang="en"  xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+        <!-- font-awesome include -->
+        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.6.0/css/all.min.css">
+        <!-- bootstrap-icons include -->
+        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
+        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous">
+        <!-- <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/line-awesome/1.3.0/line-awesome/css/line-awesome.min.css"> -->
+        <!-- JQuery import -->
+        <script src="https://code.jquery.com/jquery-3.7.1.js" integrity="sha256-eKhayi8LEQwp4NKxN+CfCh+3qOVUtJn3QNZ0TciWLP4=" crossorigin="anonymous"></script>
+        <!-- <script src="https://code.jquery.com/jquery-3.6.4.js" integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script> -->
+        <!-- js, css file import -->
+<!--        <link rel="stylesheet" href="portfolio_detail.css">-->
+<!--        <script src="portfolio_detail.js"></script>-->
+    <link rel="stylesheet" th:href="@{/css/user/portfolioDetail.css}"/>
+    <link rel="stylesheet" th:href="@{/css/fragments/header.css}">
+    <link rel="stylesheet" th:href="@{/css/fragments/footer.css}">
+    <script type="text/javascript" th:src="@{/js/user/portfolioDetail.js}"></script>
+</head>
+<body>
+    <header th:replace="~{fragments/header :: headerFragment}">
+
+    </header>
+    <main>
+        <div class="banner"></div><!--banner-->
+
+        <section>
+            <div class="mainWrap">
+                <div class="portfolioWrap">
+                    <div class="portfolioMain">
+                    <!-- 포토폴리오 첫번 째 이미지가 출력될 부분 -->
+                    </div><!--portfolioMain-->
+                    
+                    <div class="description">
+                        <div class="title">
+                            담벼리
+                        </div>
+                        <h5>포토폴리오 소개</h5>
+                    </div><!--description-->
+                    <article>
+                        <div>
+                            <!-- 이미지 파일 출력될 부분 -->
+                        </div>
+                        <div class="title">포토폴리오 설명</div>
+                        <div class="content">
+                            담벼리라는 이름은 담 + 벼리의 합성어입니다.
+                            벼리라는 뜻은 어떤 일이나 일의 뼈대를 이루는 줄거리를 말하는 순 우리말입니다.
+                            집의 입구인 대문과, 집을 두르는 담장은 나의 공간, 우리의 공간이라는 가치를 더욱 높여주는 역할을 합니다.
+                            집이 가니는 역할의 뼈대라고 생각되어지는 담장이라는 개념을 벼리라는 이름과 합하여 '담벼리'라는 이름으로 완성하였습니다.
+
+                            로고에서 보이는 그림은 좌측에 있는 대문을 표현하였고 옆으로 대문을 잇는 담장과 담장 뒤에 보이는 조경이 어우러지게 표현될 수 있도록 하였습니다.
+                        </div>
+                    </article>
+                </div><!--applyWrap-->
+
+                <aside>
+                    <figure>
+                        <div class="title">디자이너 정보</div>
+                        <div class="info">
+                            <div class="user">waylog</div>
+                                <div class="user more">
+                                디자이너 소개
+                                <i class="fa-solid fa-angle-down"></i>
+                                </div>
+                        </div>
+                        <div class="profileInfo">
+                            웨이로그디자인은 심플하고 감각적인 디자인을 추구합니다. : )
+                            남들과는 다른 한끗을 살려 고객님의 브랜드에 전문성과 퀄리티를 높이기 위해 책임감을 가지고 작업합니다.
+                            심플하면서 의미를 가득 살린 웨이로그만의 디자인으로 내 브랜드에 감성을 더해가세요 : )
+                        </div>
+                    </figure>
+                    
+                    <figure>
+                        <div class="title">디자이너님의 다른 작품</div>
+                        <div class="cardList">
+                            <div class="list">
+                                <!--포토폴리오 이미지 영역-->
+                            </div>
+                            <div class="list">
+                                <!--포토폴리오 이미지 영역-->
+                            </div>
+                            <div class="list">
+                                <!--포토폴리오 이미지 영역-->
+                            </div>
+                            <div class="list">
+                                <!--포토폴리오 이미지 영역-->
+                            </div>
+                            <div class="list"><!--더보기 영역-->
+                                <i class="fa-solid fa-plus"></i>
+                            </div>
+                        </div>
+                    </figure><!--figure-->
+                    <button type="button">디자이너에게 문의하기</button>
+                </aside><!--sectionInfo-->
+            </div><!--mainWrap-->
+            
+        </section>
+    </main>
+    <footer th:replace="~{fragments/footer :: footerFragment}">
+
+    </footer>
+</body>
+</html>


### PR DESCRIPTION
화면 구성 : background color + main 영역(포토폴리오 내용 출력 부분) + 우측 side(포토폴리오 제작자에 대한 정보) 

우측 side :
1. 포토폴리오 제작자에 대한 정보를 넣고 디자이너 정보 더 보기 클릭시 설명을 없애는 로직을 적용.
2. 제작한 포토폴리오가 여러개일 경우, 포토폴리오 이미지 출력 예정
3. 디자이너에게 문의하기 버튼 : 버튼 클릭시 채팅 페이지로 이동됨
![스크린샷 2024-09-06 163347](https://github.com/user-attachments/assets/04555af6-feab-42ef-a867-ebc4f7b06e64)
![스크린샷 2024-09-06 163526](https://github.com/user-attachments/assets/ea636d95-1bf8-496f-8265-19b1d10059da)
