### PR TITLE
페이징 로직 구현

### DIFF
--- a/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
@@ -1,10 +1,9 @@
 package com.DOH.DOH.controller.list;
 
 import com.DOH.DOH.dto.list.ContestListDTO;
+import com.DOH.DOH.dto.list.PagingDTO;
 import com.DOH.DOH.service.list.ContestListService;
 import lombok.extern.slf4j.Slf4j;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -21,10 +20,15 @@ public class ContestListController {
     private ContestListService contestListService;
 
     @GetMapping("/contest/list")
-    public String contestList(@RequestParam(name = "orderType", required = false, defaultValue = "latest")String orderType, Model model){
+    public String contestList(@RequestParam(defaultValue = "1") int page, @RequestParam(name = "orderType", required = false, defaultValue = "current")String orderType, Model model){
 
-        ArrayList<ContestListDTO> contestList = contestListService.getContestList();
+        PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
+
+
+        ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto);
         model.addAttribute("contestList", contestList);
+        model.addAttribute("pageMaker", dto);
+
         return "list/contestList";
     }
 

--- a/src/main/java/com/DOH/DOH/dto/list/ContestListDTO.java
+++ b/src/main/java/com/DOH/DOH/dto/list/ContestListDTO.java
@@ -5,11 +5,13 @@ import lombok.Data;
 @Data
 public class ContestListDTO {
 
+    private int rownum;//콘테스트 번호 역순
     private int id;//콘테스트 번호
     private String conType;//콘테스트 유형(업종)
     private String conTitle;//콘테스트 제목
     private int totalPrice;//콘테스트 총 상금
-    private String conEndDate;//콘테스트 마감일
+    private String conEndDate;//콘테스트 마감일(마감일 전체)
     private int endDate;//콘테스트 남은 기간(마감일)
     private String conCompanyName;//콘테스트 주최자명
+    private int conHit;//콘테스트 조회수
 }

--- a/src/main/java/com/DOH/DOH/dto/list/PagingDTO.java
+++ b/src/main/java/com/DOH/DOH/dto/list/PagingDTO.java
@@ -1,0 +1,38 @@
+package com.DOH.DOH.dto.list;
+
+import lombok.Data;
+
+@Data// 페이지 계산을 위해 Getter, Setter 필요 : @Data 추가
+public class PagingDTO {
+    private int startPage;     // 시작 페이지
+    private int endPage;       // 끝 페이지
+    private boolean prev, next; // 이전, 다음 버튼 활성화 여부
+    private int total;         // 총 게시물 수
+    private int currentPage;   // 현재 페이지
+    private int pageSize;      // 한 페이지당 글 수
+
+//    public PagingDTO(int currentPage, int total, int pageSize) {
+    public PagingDTO(int currentPage, int total, int pageSize) {
+        this.currentPage = currentPage;
+        this.total = total;
+        this.pageSize = pageSize;
+
+        // 끝 페이지 계산
+        this.endPage = (int) (Math.ceil(currentPage / 10.0)) * 10;
+
+        // 시작 페이지 계산
+        this.startPage = this.endPage - 9;
+
+        // 실제 끝 페이지 (총 게시물 수에 따라 계산)
+        int realEnd = (int) (Math.ceil((total * 1.0) / pageSize));
+        if (realEnd < this.endPage) {
+            this.endPage = realEnd;
+        }
+
+        // 이전 버튼 여부
+        this.prev = this.startPage > 1;
+
+        // 다음 버튼 여부
+        this.next = this.endPage < realEnd;
+    }
+}

--- a/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
@@ -1,11 +1,16 @@
 package com.DOH.DOH.mapper.list;
 
 import com.DOH.DOH.dto.list.ContestListDTO;
+import com.DOH.DOH.dto.list.PagingDTO;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.ArrayList;
 
 @Mapper
 public interface ContestListMapper {
-    public ArrayList<ContestListDTO> getContestList();
+//    public ArrayList<ContestListDTO> getContestList(@Param("offset") int offset, @Param("pageSize") int pageSize,  @Param("orderType") String orderType);
+    public ArrayList<ContestListDTO> getContestList(@Param("offset") int offset, @Param("pageSize") int pageSize);
+
+    public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListService.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListService.java
@@ -1,9 +1,15 @@
 package com.DOH.DOH.service.list;
 
 import com.DOH.DOH.dto.list.ContestListDTO;
+import com.DOH.DOH.dto.list.PagingDTO;
+import org.apache.ibatis.annotations.Param;
 
 import java.util.ArrayList;
+import java.util.List;
 
 public interface ContestListService {
-    public ArrayList<ContestListDTO> getContestList();
+//    public ArrayList<ContestListDTO> getContestList(int page, int pageSize, String orderType);
+    public ArrayList<ContestListDTO> getContestList(PagingDTO dto);
+
+    public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
@@ -1,13 +1,16 @@
 package com.DOH.DOH.service.list;
 
 import com.DOH.DOH.dto.list.ContestListDTO;
+import com.DOH.DOH.dto.list.PagingDTO;
 import com.DOH.DOH.mapper.list.ContestListMapper;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 
+@Slf4j
 @Service("ContestListService")
 public class ContestListServiceImpl implements ContestListService {
 
@@ -15,8 +18,17 @@ public class ContestListServiceImpl implements ContestListService {
     private SqlSession sqlSession;
 
     @Override
-    public ArrayList<ContestListDTO> getContestList() {
+    public ArrayList<ContestListDTO> getContestList(PagingDTO dto) {
+        ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
+        int offset = (dto.getCurrentPage() - 1) * dto.getPageSize();  // 페이징 offset 계산
+        int pageSize = dto.getPageSize();
+
+        return contestListMapper.getContestList(offset, pageSize);
+    }
+
+    public int getTotalCount(){
         ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
 
-        return contestListMapper.getContestList();
-    }}
+        return contestListMapper.getTotalCount();
+    } // 전체 게시물 수를 조회하는 메서드
+}

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -5,12 +5,31 @@
 <mapper namespace="com.DOH.DOH.mapper.list.ContestListMapper">
 
     <select id="getContestList" resultType="com.DOH.DOH.dto.list.ContestListDTO">
-        select id, conType, conTitle, (conFirstPrice * conFirstPeople
-                + conSecondPrice * conSecondPeople
-                + conThirdPrice * conThirdPeople) as totalPrice,
+        SELECT row_number() over(order by id desc) as rownum, id, conType, conTitle,
+                (conFirstPrice * conFirstPeople + conSecondPrice * conSecondPeople
+                + conThirdPrice * conThirdPeople) as totalPricee,
                 date_format(conEndDate, '%y.%m.%d') as conEndDate,
                 (datediff(conEndDate, now())) as endDate, conCompanyName
-            from contest_Upload
-            where datediff(conEndDate, now()) >= 0 order by id desc
+            FROM contest_Upload
+            WHERE datediff(conEndDate, now()) >= 0
+<!--        <choose>-->
+<!--            <when test="orderType == 'price'">&lt;!&ndash;총 상금 순&ndash;&gt;-->
+<!--                order by totalPricee desc-->
+<!--            </when>-->
+<!--            <when test="orderType == 'latest'">&lt;!&ndash;마감임박순&ndash;&gt;-->
+<!--                order by endDate asc-->
+<!--            </when>-->
+<!--            <when test="orderType == 'hit'">&lt;!&ndash;조회순&ndash;&gt;-->
+<!--                order by conHit desc-->
+<!--            </when>-->
+<!--            <otherwise>&lt;!&ndash;기본 값 : 최신순&ndash;&gt;-->
+<!--                order by rownum asc-->
+<!--            </otherwise>-->
+<!--        </choose>-->
+            limit #{offset} , #{pageSize}
+    </select>
+
+    <select id="getTotalCount" resultType="int">
+        select count(*) from contest_Upload where datediff(conEndDate, now()) >= 0
     </select>
 </mapper>

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -63,7 +63,7 @@
                                         <div class="contestHost" th:text="${list.conCompanyName}">헬스마켓</div>
                                         <div class="hit">
                                             <i class="bi bi-hand-index"></i>
-                                            <span >363</span>
+                                            <span th:text="${list.conHit}">363</span>
                                         </div>
                                     </div>
                                 </div><!--listArea-->
@@ -100,16 +100,16 @@
 
                     <nav aria-label="Page navigation example">
                         <ul class="pagination justify-content-center">
-                          <li class="page-item">
-                            <a class="page-link" href="#" aria-label="Previous">
+                          <li class="page-item" th:if="${pageMaker.prev}">
+                            <a class="page-link" th:href="@{/contest/list(page=${pageMaker.startPage - 1}, orderType=${param.orderType})}" aria-label="Previous">
                               <span aria-hidden="true">&laquo;</span>
                             </a>
                           </li>
-                          <li class="page-item"><a class="page-link" href="#">1</a></li>
-                          <li class="page-item"><a class="page-link" href="#">2</a></li>
-                          <li class="page-item"><a class="page-link" href="#">3</a></li>
-                          <li class="page-item">
-                            <a class="page-link" href="#" aria-label="Next">
+                          <li class="page-item" th:each="i : ${#numbers.sequence(pageMaker.startPage, pageMaker.endPage)}">
+                              <a class="page-link" th:text="${i}" th:href="@{/contest/list(page=${i}, orderType=${param.orderType})}">3</a>
+                          </li>
+                          <li class="page-item" th:if="${pageMaker.next}">
+                            <a class="page-link" th:href="@{/contest/list(page=${pageMaker.endPage + 1}, orderType=${param.orderType})}" aria-label="Next">
                               <span aria-hidden="true">&raquo;</span>
                             </a>
                           </li>


### PR DESCRIPTION
페이지별 출력될 목록의 수가 달라 페이징 로직이 여러 개 필요하다는 문제를 해결하기 위해 controller 단에서 해당 페이지의 한 페이지에 출력될 목록의 수를 변수로 설정하여 페이징 기능을 구현하도록 페이징 로직을 독립적으로 구현함
페이징 기능 예시 화면 :
![스크린샷 2024-09-12 125759](https://github.com/user-attachments/assets/99e5e1e6-696b-4098-aed6-1487d1352c3a)
