### PR TITLE
포토폴리오 목록 페이지 markup

### DIFF
--- a/src/main/java/com/DOH/DOH/controller/list/ProfileListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ProfileListController.java
@@ -2,8 +2,14 @@ package com.DOH.DOH.controller.list;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
 
 @Slf4j
 @Controller
 public class ProfileListController {
+
+    @GetMapping("/portfolio/list")
+    public String portfolioList(){
+        return "list/portfolioList";
+    }
 }

--- a/src/main/resources/static/css/list/portfolioList.css
+++ b/src/main/resources/static/css/list/portfolioList.css
@@ -1,0 +1,137 @@
+    :root
+    {
+        --main-color : #c1c0ff;
+        --sub-color : #ECFCE4;
+        --color-black : #000;
+        --dark-gray : #757575;
+        --line-gray: #D9D9D9;
+        --color-white : #fff;
+        
+        --font-size-32 : 32px;
+        --font-size-24 : 24px;
+        --font-size-20 : 20px;
+        --font-size-16 : 16px;
+        --font-size-14 : 14px;
+
+    }
+
+    a
+    {
+        color: var(--color-black);
+        text-decoration: none;
+    }
+
+
+    /* main 영역 */
+    main
+    {
+        display: flex;
+        justify-content: center;
+    }
+
+    .mainWrap
+    {
+        display: flex;
+        flex-direction: column;/* 요소들을 세로로 정렬 */
+        /* min-width: 1200px; */
+        max-width: 1200px;
+        width: 100%;
+        margin: 90px 0;
+    }
+
+    .filterWrap
+    {
+        display: flex;
+        width: 100%;
+        justify-content: space-between;
+        align-items: center;
+    }
+
+    .filter.left
+    {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        gap: 15px;
+        list-style-type: none;/*li 태그 점 없애기*/
+        padding-left: 0;
+    }
+
+    input[type="checkbox"]
+    { 
+        appearance: none; /* 기본 브라우저 스타일 제거 */
+        -webkit-appearance: none; /* WebKit 기반 브라우저에서 기본 스타일 제거 */
+        outline: none;
+    } 
+
+    button
+    {
+        border: 1px solid var(--line-gray);
+        border-radius: 6px;
+        background: var(--color-white);
+        padding: 5px 10px;
+    }
+
+    /* section */
+
+    section
+    {
+        /* display: flex; */
+        /* justify-content: space-between; */
+        display: grid;
+        grid-template-columns: 1fr 1fr 1fr 1fr;
+        width: 100%;
+        gap: 20px;
+        /* flex-wrap: wrap; */
+        margin: 20px 0;
+        box-sizing: border-box; /* 박스 크기에 패딩과 보더 포함 */
+    }
+
+    .cardList
+    {
+        /* width: clac(25% - 20px); */
+        height: 300px;
+        border: 1px solid var(--line-gray);
+        border-radius: 6px;
+        display: block;
+        transition: all 0.5s;
+        &:hover
+        {
+            transform: scale(1.05);
+            box-shadow: 0 5px 10px rgba(0,0,0,0.25);
+        }
+    }
+
+    .cardList .img
+    {
+        width: 100%;
+        height: 200px;
+        background-color: var(--sub-color);
+    }
+
+    .portfolioSummary
+    {
+        padding: 20px;
+        box-sizing: border-box;
+    }
+
+    .portfolioSummary .info
+    {
+
+        display: flex;
+        gap: 10px;
+        align-items: center;
+    }
+
+    .portfolioSummary *
+    {
+        font-size: var(--font-size-14);
+        font-weight: 300;
+        margin-bottom: 0;
+    }
+
+    .portfolioSummary .title
+    {
+        font-size: var(--font-size-16);
+        font-weight: 900;
+    }

--- a/src/main/resources/templates/list/portfolioList.html
+++ b/src/main/resources/templates/list/portfolioList.html
@@ -1,0 +1,338 @@
+<!DOCTYPE html>
+<html lang="en" xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.ultraq.net.nz/thymeleaf/layout"
+      layout:decorate="/fragments/layout">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+    <!-- jQuery 추가 -->
+    <script src="https://code.jquery.com/jquery-3.6.4.js"
+            integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script>
+
+    <!-- Bootstrap CSS -->
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
+
+    <!-- 커스텀 CSS 및 JS 추가 -->
+    <link rel="stylesheet" th:href="@{/css/list/portfolioList.css}">
+    <link rel="stylesheet" th:href="@{/css/fragments/header.css}">
+    <link rel="stylesheet" th:href="@{/css/fragments/footer.css}">
+
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.1/font/bootstrap-icons.css">
+</head>
+<body>
+<th:block layout:fragment="content">
+    <main>
+        <div class="mainWrap">
+            <nav class="filterWrap">
+                <div class="filter left">
+                    <!-- <button type="button">
+                        <i class="fa-solid fa-crown"></i>
+                        콘테스트 우승
+                    </button> -->
+                    <div>
+                        <label class="type">
+                            <input type="checkbox" name="" id="#" class="check">
+                            <i class="fa-solid fa-crown"></i>
+                            콘테스트 우승
+                        </label>
+                    </div>
+                    <!-- <button type="button"> -->
+                    <div>
+                        <label class="type">
+                            <input type="checkbox" name="" id="" class="check">
+                            <i class="fa-solid fa-people-arrows"></i>
+                            1 : 1 의뢰 가능
+                        </label>
+                    </div>
+                    <!-- </button> -->
+                </div><!--filter left-->
+
+                <!-- <div class="filter right"> -->
+                    <button type="button" class="filter right">
+                        추천순
+                    </button>
+                <!-- </div>filter right -->
+            </nav><!--filterWrap-->
+            
+            <section>
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+                <div class="cardList">
+                    <a href="#">
+                        <div class="img">
+                            <!--포토폴리오가 들어갈 영역-->
+                        </div>
+                        <div class="portfolioSummary">
+                            <div class="title">식품 브랜드 밀잇 브랜드 콘테스트</div>
+                            <div class="info">
+                                <h5>싱싱한초록546</h5> ·
+                                <div class="hit">
+                                    조회수 363
+                                </div>
+                            </div>
+                        </div>
+                    </a>
+                </div><!--cardList-->
+            </section>
+
+            <nav aria-label="Page navigation example">
+                <ul class="pagination justify-content-center">
+                  <li class="page-item">
+                    <a class="page-link" href="#" aria-label="Previous">
+                      <span aria-hidden="true">&laquo;</span>
+                    </a>
+                  </li>
+                  <li class="page-item"><a class="page-link" href="#">1</a></li>
+                  <li class="page-item"><a class="page-link" href="#">2</a></li>
+                  <li class="page-item"><a class="page-link" href="#">3</a></li>
+                  <li class="page-item">
+                    <a class="page-link" href="#" aria-label="Next">
+                      <span aria-hidden="true">&raquo;</span>
+                    </a>
+                  </li>
+                </ul>
+              </nav>
+        </div><!--mainWrap-->
+    </main>
+</th:block>
+</body>
+</html>


### PR DESCRIPTION
포토폴리오 목록 페이지 마크업 작업 완료

구성 : 필터링/정렬 버튼 + 포토폴리오 목록 + 페이징 버튼
포토폴리오 목록 : 한 페이지에 16개의 목록이 출력됨

수정/보완 사항 : 
1. 필터링 기능에 대한 JS 로직 미완성
2. DB에 정보가 없어 출력 및 페이징 기능 미적용

![image](https://github.com/user-attachments/assets/d751bd2b-c6bd-41e8-95a1-299de489d2ef)
![image](https://github.com/user-attachments/assets/01df2742-b4b4-4973-a977-8040b20ccf3e)
