### PR TITLE
공모전 목록 페이지 조회수 증가 기능 추가

### DIFF
--- a/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
@@ -10,10 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.ArrayList;
@@ -38,6 +35,13 @@ public class ContestListController {
         model.addAttribute("pageMaker", dto);
 
         return "list/contestList";
+    }
+
+    @PostMapping("/hitUp")
+    @ResponseBody
+    public void hitUp(int contestId){
+        log.info("콘테스트 번호 이동"+contestId);
+        contestListService.hitUp(contestId);
     }
 
 }

--- a/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
@@ -15,4 +15,5 @@ public interface ContestListMapper {
 
     public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
     public void saveContestApply(ApplyDTO dto);
+    void hitUp(int contestId);
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListService.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListService.java
@@ -14,4 +14,5 @@ public interface ContestListService {
 
     public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
     public void saveContestApply(ApplyDTO dto);
+    public void hitUp(int contestId);//조회수 증가 메서드
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
@@ -40,4 +40,8 @@ public class ContestListServiceImpl implements ContestListService {
       // ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
         contestListMapper.saveContestApply(dto);
     }
+
+    public void hitUp(int contestId) {//조회수 증가 메서드
+        contestListMapper.hitUp(contestId);
+    }
 }

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -37,4 +37,8 @@
         insert into apply_contest(conNum, userNum, applyTitle, applyContent, applyDate)
         values(#{conNum}, #{userNum}, #{applyTitle}, #{applyContent}, curdate())
     </insert>
+
+    <update id="hitUp">
+        update contest_Upload set conHit = ifnull(conHit, 0) +1 where id = #{contestId}
+    </update>
 </mapper>

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -1,7 +1,7 @@
 
 function hitUp(e) {
    console.log("test");
-   var id = $(e).siblings("input#contestId").val();
+   var id = $(e).siblings("#contestId").val();
    console.log(id);
 
        $.ajax({

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -1,0 +1,23 @@
+
+function hitUp() {
+   console.log("test");
+   var id = document.getElementById('contestId').value;
+   console.log(id);
+
+    // Ajax로 서버에 contestId 값을 보내는 로직
+       $.ajax({
+           url: '/contest/hitUp',  // 조회수 증가 API 경로
+           type: 'POST',
+           data: { contestId: id },
+           success: function() {
+               // 조회수 증가 성공 시 페이지 이동
+               console.log('조회수 증가 완료');
+               window.location.href = '/contest/view/?contestId=' + id;  // 페이지 이동
+           },
+           error: function() {
+               // 조회수 증가 실패 시 에러 처리
+               console.log('조회수 증가 중 오류 발생:', error);
+           }
+       });
+
+}

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -1,18 +1,17 @@
 
-function hitUp() {
+function hitUp(e) {
    console.log("test");
-   var id = document.getElementById('contestId').value;
+   var id = $(e).siblings("input#contestId").val();
    console.log(id);
 
-    // Ajax로 서버에 contestId 값을 보내는 로직
        $.ajax({
-           url: '/contest/hitUp',  // 조회수 증가 API 경로
+           url: '/contest/hitUp',
            type: 'POST',
            data: { contestId: id },
            success: function() {
                // 조회수 증가 성공 시 페이지 이동
                console.log('조회수 증가 완료');
-               window.location.href = '/contest/view/?contestId=' + id;  // 페이지 이동
+               location.href = '/contest/view?contestId='+ id;  // 페이지 이동
            },
            error: function() {
                // 조회수 증가 실패 시 에러 처리

--- a/src/main/resources/static/js/list/quickMenu.js
+++ b/src/main/resources/static/js/list/quickMenu.js
@@ -27,16 +27,16 @@ function scrollToTop() {
 }
 
 // WebSocket 연결 및 메시지 수신 로직
-//const socket = new SockJS('/your-websocket-endpoint');
-//const stompClient = Stomp.over(socket);
+const socket = new SockJS('/your-websocket-endpoint');
+const stompClient = Stomp.over(socket);
 
-//stompClient.connect({}, function (frame) {
-//    // 구독 경로 설정 (로그인된 사용자의 ID에 맞게 설정)
-//    const userId = document.getElementById("userId").value; // 사용자 ID를 세션에서 가져옴
-//    stompClient.subscribe('/user/' + userId + '/queue/messages', function (messageOutput) {
-//        showNotificationIcon(); // 메시지 수신 시 알림 배지 표시
-//    });
-//});
+stompClient.connect({}, function (frame) {
+    // 구독 경로 설정 (로그인된 사용자의 ID에 맞게 설정)
+    const userId = document.getElementById("userId").value; // 사용자 ID를 세션에서 가져옴
+    stompClient.subscribe('/user/' + userId + '/queue/messages', function (messageOutput) {
+        showNotificationIcon(); // 메시지 수신 시 알림 배지 표시
+    });
+});
 
 // 알림 배지를 표시하는 함수
 function showNotificationIcon() {

--- a/src/main/resources/static/js/list/quickMenu.js
+++ b/src/main/resources/static/js/list/quickMenu.js
@@ -27,16 +27,16 @@ function scrollToTop() {
 }
 
 // WebSocket 연결 및 메시지 수신 로직
-const socket = new SockJS('/your-websocket-endpoint');
-const stompClient = Stomp.over(socket);
+//const socket = new SockJS('/your-websocket-endpoint');
+//const stompClient = Stomp.over(socket);
 
-stompClient.connect({}, function (frame) {
-    // 구독 경로 설정 (로그인된 사용자의 ID에 맞게 설정)
-    const userId = document.getElementById("userId").value; // 사용자 ID를 세션에서 가져옴
-    stompClient.subscribe('/user/' + userId + '/queue/messages', function (messageOutput) {
-        showNotificationIcon(); // 메시지 수신 시 알림 배지 표시
-    });
-});
+//stompClient.connect({}, function (frame) {
+//    // 구독 경로 설정 (로그인된 사용자의 ID에 맞게 설정)
+//    const userId = document.getElementById("userId").value; // 사용자 ID를 세션에서 가져옴
+//    stompClient.subscribe('/user/' + userId + '/queue/messages', function (messageOutput) {
+//        showNotificationIcon(); // 메시지 수신 시 알림 배지 표시
+//    });
+//});
 
 // 알림 배지를 표시하는 함수
 function showNotificationIcon() {

--- a/src/main/resources/templates/fragments/layout.html
+++ b/src/main/resources/templates/fragments/layout.html
@@ -8,9 +8,9 @@
             integrity="sha256-a9jBBRygX1Bh5lt8GZjXDzyOB+bWve9EiO7tROUtj/E=" crossorigin="anonymous"></script>
 
     <!-- jQuery CDN (최신 버전) -->
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"
-            integrity="sha256-JlPkFq1dsJz5Y1J8AmSNxT4Ofu1idGZZ84dQvYB2eDs="
-            crossorigin="anonymous"></script>
+<!--    <script src="https://code.jquery.com/jquery-3.7.1.min.js"-->
+<!--            integrity="sha256-JlPkFq1dsJz5Y1J8AmSNxT4Ofu1idGZZ84dQvYB2eDs="-->
+<!--            crossorigin="anonymous"></script>-->
 
     <!-- Bootstrap CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -30,7 +30,9 @@
                     <div class="contestWrap">
 
                         <div class="listValue" th:each="list : ${contestList}">
-                            <a href="#" th:href="@{/contest/view(contestId=${list.id})}">
+<!--                            <a href="#" th:href="@{/contest/view(contestId=${list.id})}" th:onclick="hitUp(${list.id})">-->
+                            <input type="hidden" id="contestId" th:value="${list.id}">
+                            <a href="#" th:onclick="hitUp()">
                             <div class="listArea">
                                 <div class="content A">
                                     <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -30,9 +30,8 @@
                     <div class="contestWrap">
 
                         <div class="listValue" th:each="list : ${contestList}">
-<!--                            <a href="#" th:href="@{/contest/view(contestId=${list.id})}" th:onclick="hitUp(${list.id})">-->
                             <input type="hidden" id="contestId" th:value="${list.id}">
-                            <a href="#" th:onclick="hitUp()">
+                            <a href="#" th:onclick="hitUp(this)">
                             <div class="listArea">
                                 <div class="content A">
                                     <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>


### PR DESCRIPTION
공모전 목록 페이지 조회수 증가 기능 추가
: 공모전 목록 페이지에서 공모전 클릭시 해당 공모전의 조회수를 증가하는 로직 추가
![image](https://github.com/user-attachments/assets/58726e44-8f2a-4b00-9db5-acb1eb22240d)
해당 로직 기능테스트 이미지

→ conHit가 기본 null로 설정되어 있어 ifnull( , ) 함수를 이용해 조회수를 증가시킴