### PR TITLE
103 알림 드롭다운 기능 추가

### DIFF
--- a/src/main/resources/static/css/fragments/header.css
+++ b/src/main/resources/static/css/fragments/header.css
@@ -156,3 +156,14 @@ html {
     color: rgb(193, 192, 255);
     transform: scale(1.1);
 }
+
+.notification-badge {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+    background-color: rgb(193, 192, 255);
+    color: white;
+    padding: 3px 7px;
+    border-radius: 50%;
+    font-size: 12px;
+}

--- a/src/main/resources/static/css/fragments/header.css
+++ b/src/main/resources/static/css/fragments/header.css
@@ -167,3 +167,16 @@ html {
     border-radius: 50%;
     font-size: 12px;
 }
+
+.nav-tabs {
+    margin-bottom: 10px;
+}
+
+.list-group-item {
+    padding: 10px;
+    border-bottom: 1px solid #ddd;
+}
+
+.list-group-item:hover {
+    background-color: #f1f1f1;
+}

--- a/src/main/resources/static/js/user/header.js
+++ b/src/main/resources/static/js/user/header.js
@@ -1,0 +1,6 @@
+document.addEventListener('DOMContentLoaded', function () {
+    var dropdownTriggerList = [].slice.call(document.querySelectorAll('.dropdown-toggle'))
+    var dropdownList = dropdownTriggerList.map(function (dropdownToggleEl) {
+        return new bootstrap.Dropdown(dropdownToggleEl)
+    });
+});

--- a/src/main/resources/static/js/user/header.js
+++ b/src/main/resources/static/js/user/header.js
@@ -4,3 +4,4 @@ document.addEventListener('DOMContentLoaded', function () {
         return new bootstrap.Dropdown(dropdownToggleEl)
     });
 });
+

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -3,6 +3,7 @@
 <head>
     <link rel="stylesheet" th:href="@{/js/user/header.js}">
 </head>
+
 <th:block th:fragment="headerFragment">
     <header class="header">
         <nav class="navbar">

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -1,5 +1,8 @@
 <!DOCTYPE html>
 <html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <link rel="stylesheet" th:href="@{/js/user/header.js}">
+</head>
 <th:block th:fragment="headerFragment">
     <header class="header">
         <nav class="navbar">
@@ -39,15 +42,22 @@
                     <div th:if="${userEmail != 'anonymousUser'}" class="login-links">
 
                         <!-- 알림 아이콘 (관리자가 아닌 경우만) -->
-                        <div th:if="${userRole != 'ROLE_ADMIN'}" class="link-item">
+                        <div th:if="${userRole != 'ROLE_ADMIN'}" class="link-item dropdown">
                             <!-- 알림 아이콘 -->
-                            <div th:if="true">
+                            <div class="dropdown-toggle" id="notificationDropdown" data-bs-toggle="dropdown" aria-expanded="false" style="cursor: pointer;">
                                 <i class="fa-regular fa-bell"></i> <!-- 알림 없음 -->
+                                <span class="notification-badge" th:if="${hasUnreadNotifications}">N</span>
                             </div>
-                            <div th:if="false" style="position: relative;">
-                                <i class="fa-regular fa-bell" style="position: relative;"></i> <!-- 알림 있음 -->
-                                <span class="notification-badge">N</span>
-                            </div>
+                            <!-- 알림 드롭다운 메뉴 -->
+                            <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="notificationDropdown">
+                                <li th:each="notification : ${notificationList}">
+                                    <a class="dropdown-item" th:text="${notification.message}" th:href="${notification.url}"></a>
+                                </li>
+                                <!-- 알림이 없는 경우 -->
+                                <li th:if="${#lists.isEmpty(notificationList)}">
+                                    <a class="dropdown-item">새로운 알림이 없습니다.</a>
+                                </li>
+                            </ul>
                         </div>
 
                         <!-- 관리자가 아닌 경우에만 이메일을 마이페이지 링크로 감싸기 -->

--- a/src/main/resources/templates/fragments/header.html
+++ b/src/main/resources/templates/fragments/header.html
@@ -62,7 +62,7 @@
 
                         <!-- 관리자가 아닌 경우에만 이메일을 마이페이지 링크로 감싸기 -->
                         <div th:if="${userRole != 'ROLE_ADMIN'}" class="link-item">
-                            <a class="nav-link" th:href="@{/users/mypage}" th:text="${userEmail}"></a>
+                            <a class="nav-link" th:href="@{/users/mypage}" th:text="${nickName}"></a>
                         </div>
 
                         <!-- 관리자인 경우 이메일만 표시 -->


### PR DESCRIPTION
![image (1)](https://github.com/user-attachments/assets/020e392e-06f6-48ef-9a01-7213e2fb9a9e)
![image](https://github.com/user-attachments/assets/72a7ad03-f6c3-48d9-8bbe-e08ff928e2fa)

헤더에 알림 드롭다운 기능을 추가하여 사용자들이 새로운 알림을 확인할 수 있도록 개선합니다.

* 알림 아이콘을 클릭하면 드롭다운 메뉴가 열리며, 최근 알림 목록이 표시됨.
* 알림 항목 클릭 시 관련 페이지로 이동.
* 알림 목록에서 읽지 않은 알림을 별도로 표시.
* 알림이 없을 경우 "알림이 없습니다." 메시지 표시.
* CSS 및 JavaScript를 사용하여 드롭다운 구현.

