### PR TITLE
콘테스트 리스트 페이지 정렬 기능 및 스크랩 기능 추가

### DIFF
--- a/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
@@ -11,6 +11,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
 
 import java.security.Principal;
 import java.util.ArrayList;
@@ -29,23 +30,54 @@ public class ContestListController {
                               @RequestParam(name = "orderType", defaultValue = "current")String orderType,
                               Principal principal, Model model){
 
+//        log.info("orderType 테스트!! "+orderType);
+//        if (principal != null) { // principal이 null이 아닌 경우 처리
+//            String userEmail = principal.getName();
+//            if (userEmail != null) {
+//                ArrayList<Integer> scrapList = contestListService.getScrapList(userEmail);
+//                log.info("scrapList" + scrapList);
+//                model.addAttribute("scrapList", scrapList);
+//            }
+//        }
+
+        //PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
+
+        //ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto, orderType);
+        //model.addAttribute("contestList", contestList);
+        //model.addAttribute("pageMaker", dto);
+
+        return "list/contestList";
+    }
+
+    @GetMapping("/list_ajax")
+    public ModelAndView contestList(@RequestParam(defaultValue = "1") int page,
+                                    @RequestParam(name = "orderType", defaultValue = "current")String orderType,
+                                    Principal principal){ //, Model model){
+
         log.info("orderType 테스트!! "+orderType);
+        ModelAndView mav = new ModelAndView();
+        mav.setViewName("/list/contestWrap_ajax");
+
         if (principal != null) { // principal이 null이 아닌 경우 처리
             String userEmail = principal.getName();
             if (userEmail != null) {
                 ArrayList<Integer> scrapList = contestListService.getScrapList(userEmail);
                 log.info("scrapList" + scrapList);
-                model.addAttribute("scrapList", scrapList);
+                //model.addAttribute("scrapList", scrapList);
+                mav.addObject("scrapList", scrapList);
             }
         }
 
         PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
 
         ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto, orderType);
-        model.addAttribute("contestList", contestList);
-        model.addAttribute("pageMaker", dto);
+        //model.addAttribute("contestList", contestList);
+        //model.addAttribute("pageMaker", dto);
 
-        return "list/contestList";
+        mav.addObject("contestList", contestList);
+        mav.addObject("pageMaker", dto);
+
+        return mav;
     }
 
     @PostMapping("/scrap")

--- a/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
@@ -1,18 +1,17 @@
 package com.DOH.DOH.controller.list;
 
-import com.DOH.DOH.dto.list.ApplyDTO;
 import com.DOH.DOH.dto.list.ContestListDTO;
 import com.DOH.DOH.dto.list.PagingDTO;
 import com.DOH.DOH.service.list.ContestListService;
-import com.DOH.DOH.service.list.S3Service;
+import com.DOH.DOH.service.user.UserSessionService;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
+import java.security.Principal;
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -25,16 +24,35 @@ public class ContestListController {
     private ContestListService contestListService;
 
     @GetMapping("/list")
-    public String contestList(@RequestParam(defaultValue = "1") int page, @RequestParam(name = "orderType", required = false, defaultValue = "current")String orderType, Model model){
+    public String contestList(@RequestParam(defaultValue = "1") int page,
+                              @RequestParam(name = "orderType", defaultValue = "current")String orderType,
+                              Principal principal,Model model){
 
+        String userEmail = principal.getName();
+        if(userEmail != null){
+            model.addAttribute("userEmail", userEmail);
+        }
         PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
-
 
         ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto);
         model.addAttribute("contestList", contestList);
         model.addAttribute("pageMaker", dto);
 
         return "list/contestList";
+    }
+
+    @PostMapping("/scrap")
+    @ResponseBody
+//    public void scrap(Principal principal, int contestId){
+    public void scrap(@RequestParam HashMap<String,String> param){
+//        log.info("스크랩 할 번호"+contestId);
+//        String email = principal.getName();
+//        log.info("email test!! "+email);
+
+
+//            boolean scrap = contestListService.scrap(email, contestId);
+            boolean scrap = contestListService.scrap(param);
+//        contestListService.hitUp(contestId);
     }
 
     @PostMapping("/hitUp")

--- a/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
@@ -7,6 +7,7 @@ import com.DOH.DOH.service.user.UserSessionService;
 import jakarta.servlet.http.HttpSession;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.*;
@@ -26,12 +27,18 @@ public class ContestListController {
     @GetMapping("/list")
     public String contestList(@RequestParam(defaultValue = "1") int page,
                               @RequestParam(name = "orderType", defaultValue = "current")String orderType,
-                              Principal principal,Model model){
+                              Principal principal, Model model){
 
-        String userEmail = principal.getName();
-        if(userEmail != null){
-            model.addAttribute("userEmail", userEmail);
+
+        if (principal != null) { // principal이 null이 아닌 경우 처리
+            String userEmail = principal.getName();
+            if (userEmail != null) {
+                ArrayList<Integer> scrapList = contestListService.getScrapList(userEmail);
+                log.info("scrapList" + scrapList);
+                model.addAttribute("scrapList", scrapList);
+            }
         }
+
         PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
 
         ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto);
@@ -43,16 +50,18 @@ public class ContestListController {
 
     @PostMapping("/scrap")
     @ResponseBody
-//    public void scrap(Principal principal, int contestId){
-    public void scrap(@RequestParam HashMap<String,String> param){
-//        log.info("스크랩 할 번호"+contestId);
-//        String email = principal.getName();
-//        log.info("email test!! "+email);
+    public int scrap(Principal principal, int contestId){
+        log.info("스크랩 할 번호"+contestId);
+        int result = 0;
+        if (principal != null) { // principal이 null이 아닌 경우 처리
+            String userEmail = principal.getName();
+            log.info("email test!! " + userEmail);
+            result = contestListService.scrap(userEmail, contestId);
+        }else{
+            result = 2;
+        }
 
-
-//            boolean scrap = contestListService.scrap(email, contestId);
-            boolean scrap = contestListService.scrap(param);
-//        contestListService.hitUp(contestId);
+        return result;
     }
 
     @PostMapping("/hitUp")

--- a/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
@@ -29,7 +29,7 @@ public class ContestListController {
                               @RequestParam(name = "orderType", defaultValue = "current")String orderType,
                               Principal principal, Model model){
 
-
+        log.info("orderType 테스트!! "+orderType);
         if (principal != null) { // principal이 null이 아닌 경우 처리
             String userEmail = principal.getName();
             if (userEmail != null) {
@@ -41,7 +41,7 @@ public class ContestListController {
 
         PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
 
-        ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto);
+        ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto, orderType);
         model.addAttribute("contestList", contestList);
         model.addAttribute("pageMaker", dto);
 

--- a/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ContestListController.java
@@ -26,33 +26,15 @@ public class ContestListController {
     private ContestListService contestListService;
 
     @GetMapping("/list")
-    public String contestList(@RequestParam(defaultValue = "1") int page,
-                              @RequestParam(name = "orderType", defaultValue = "current")String orderType,
-                              Principal principal, Model model){
-
-//        log.info("orderType 테스트!! "+orderType);
-//        if (principal != null) { // principal이 null이 아닌 경우 처리
-//            String userEmail = principal.getName();
-//            if (userEmail != null) {
-//                ArrayList<Integer> scrapList = contestListService.getScrapList(userEmail);
-//                log.info("scrapList" + scrapList);
-//                model.addAttribute("scrapList", scrapList);
-//            }
-//        }
-
-        //PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
-
-        //ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto, orderType);
-        //model.addAttribute("contestList", contestList);
-        //model.addAttribute("pageMaker", dto);
+    public String contestList(){
 
         return "list/contestList";
     }
 
     @GetMapping("/list_ajax")
     public ModelAndView contestList(@RequestParam(defaultValue = "1") int page,
-                                    @RequestParam(name = "orderType", defaultValue = "current")String orderType,
-                                    Principal principal){ //, Model model){
+                                    @RequestParam(name = "orderType")String orderType,
+                                    Principal principal){
 
         log.info("orderType 테스트!! "+orderType);
         ModelAndView mav = new ModelAndView();
@@ -63,7 +45,6 @@ public class ContestListController {
             if (userEmail != null) {
                 ArrayList<Integer> scrapList = contestListService.getScrapList(userEmail);
                 log.info("scrapList" + scrapList);
-                //model.addAttribute("scrapList", scrapList);
                 mav.addObject("scrapList", scrapList);
             }
         }
@@ -71,8 +52,6 @@ public class ContestListController {
         PagingDTO dto = new PagingDTO(page,contestListService.getTotalCount(),10);
 
         ArrayList<ContestListDTO> contestList = contestListService.getContestList(dto, orderType);
-        //model.addAttribute("contestList", contestList);
-        //model.addAttribute("pageMaker", dto);
 
         mav.addObject("contestList", contestList);
         mav.addObject("pageMaker", dto);
@@ -83,7 +62,7 @@ public class ContestListController {
     @PostMapping("/scrap")
     @ResponseBody
     public int scrap(Principal principal, int contestId){
-        log.info("스크랩 할 번호"+contestId);
+        log.info("스크랩 할 번호 ---->"+contestId);
         int result = 0;
         if (principal != null) { // principal이 null이 아닌 경우 처리
             String userEmail = principal.getName();

--- a/src/main/java/com/DOH/DOH/dto/list/ApplyDTO.java
+++ b/src/main/java/com/DOH/DOH/dto/list/ApplyDTO.java
@@ -7,7 +7,7 @@ import java.util.Date;
 @Data
 public class ApplyDTO {
     private int conNum;
-    private int userNum;
+    private String userEmail;
     private String applyTitle;
     private String applyContent;
     private Date applyDate;

--- a/src/main/java/com/DOH/DOH/dto/list/ContestListDTO.java
+++ b/src/main/java/com/DOH/DOH/dto/list/ContestListDTO.java
@@ -6,7 +6,8 @@ import lombok.Data;
 public class ContestListDTO {
 
     private int rownum;//콘테스트 번호 역순
-    private Long id;//콘테스트 번호
+//    private Long id;//콘테스트 번호 : 타입 불일치로 변경함
+    private int id;//콘테스트 번호
     private String conType;//콘테스트 유형(업종)
     private String conTitle;//콘테스트 제목
     private int totalPrice;//콘테스트 총 상금

--- a/src/main/java/com/DOH/DOH/dto/list/MainDTO.java
+++ b/src/main/java/com/DOH/DOH/dto/list/MainDTO.java
@@ -1,4 +1,0 @@
-package com.DOH.DOH.dto.list;
-
-public class MainDTO {
-}

--- a/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
@@ -2,11 +2,12 @@ package com.DOH.DOH.mapper.list;
 
 import com.DOH.DOH.dto.list.ApplyDTO;
 import com.DOH.DOH.dto.list.ContestListDTO;
-import com.DOH.DOH.dto.list.PagingDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 
 @Mapper
 public interface ContestListMapper {
@@ -16,4 +17,10 @@ public interface ContestListMapper {
     public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
     public void saveContestApply(ApplyDTO dto);
     void hitUp(int contestId);
+
+//    boolean searchScrap(@Param("userEmail") String uerEmail,@Param("conestId") int contestId);
+    boolean searchScrap(@RequestParam HashMap<String, String> param);
+//    void addScrap(@Param("userEmail") String uerEmail,@Param("conestId") int contestId);
+    void addScrap(@RequestParam HashMap<String, String> param);
+    void deleteScrap(@RequestParam HashMap<String, String> param);
 }

--- a/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
@@ -18,9 +18,8 @@ public interface ContestListMapper {
     public void saveContestApply(ApplyDTO dto);
     void hitUp(int contestId);
 
-//    boolean searchScrap(@Param("userEmail") String uerEmail,@Param("conestId") int contestId);
-    boolean searchScrap(@RequestParam HashMap<String, String> param);
-//    void addScrap(@Param("userEmail") String uerEmail,@Param("conestId") int contestId);
-    void addScrap(@RequestParam HashMap<String, String> param);
-    void deleteScrap(@RequestParam HashMap<String, String> param);
+    ArrayList<Integer> getScrapList(String userEmail);
+    int searchScrap(@Param("userEmail") String userEmail,@Param("contestId") int contestId);
+    void addScrap(@Param("userEmail") String uerEmail,@Param("contestId") int contestId);
+    void deleteScrap(@Param("userEmail") String uerEmail,@Param("contestId") int contestId);
 }

--- a/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
@@ -11,8 +11,8 @@ import java.util.HashMap;
 
 @Mapper
 public interface ContestListMapper {
-//    public ArrayList<ContestListDTO> getContestList(@Param("offset") int offset, @Param("pageSize") int pageSize,  @Param("orderType") String orderType);
-    public ArrayList<ContestListDTO> getContestList(@Param("offset") int offset, @Param("pageSize") int pageSize);
+    public ArrayList<ContestListDTO> getContestList(@Param("offset") int offset, @Param("pageSize") int pageSize,  @Param("orderType") String orderType);
+//    public ArrayList<ContestListDTO> getContestList(@Param("offset") int offset, @Param("pageSize") int pageSize);
 
     public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
     public void saveContestApply(ApplyDTO dto);

--- a/src/main/java/com/DOH/DOH/service/list/ContestListService.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListService.java
@@ -13,7 +13,7 @@ import java.util.List;
 
 public interface ContestListService {
 //    public ArrayList<ContestListDTO> getContestList(int page, int pageSize, String orderType);
-    public ArrayList<ContestListDTO> getContestList(PagingDTO dto);
+    public ArrayList<ContestListDTO> getContestList(PagingDTO dto, String orderType);
 
     public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
     public void saveContestApply(ApplyDTO dto);

--- a/src/main/java/com/DOH/DOH/service/list/ContestListService.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListService.java
@@ -4,8 +4,11 @@ import com.DOH.DOH.dto.list.ApplyDTO;
 import com.DOH.DOH.dto.list.ContestListDTO;
 import com.DOH.DOH.dto.list.PagingDTO;
 import org.apache.ibatis.annotations.Param;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
 import java.util.List;
 
 public interface ContestListService {
@@ -15,4 +18,6 @@ public interface ContestListService {
     public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
     public void saveContestApply(ApplyDTO dto);
     public void hitUp(int contestId);//조회수 증가 메서드
+//    boolean scrap(String email, int contestId);
+    boolean scrap(@RequestParam HashMap<String, String> param);
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListService.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListService.java
@@ -18,6 +18,6 @@ public interface ContestListService {
     public int getTotalCount(); // 전체 게시물 수를 조회하는 메서드
     public void saveContestApply(ApplyDTO dto);
     public void hitUp(int contestId);//조회수 증가 메서드
-//    boolean scrap(String email, int contestId);
-    boolean scrap(@RequestParam HashMap<String, String> param);
+    ArrayList<Integer> getScrapList(String userEmail);
+    int scrap(String email, int contestId);
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
@@ -23,11 +23,12 @@ public class ContestListServiceImpl implements ContestListService {
     ContestListMapper contestListMapper;
 
     @Override
-    public ArrayList<ContestListDTO> getContestList(PagingDTO dto) {
+//    public ArrayList<ContestListDTO> getContestList(PagingDTO dto) {
+    public ArrayList<ContestListDTO> getContestList(PagingDTO dto, String orderType) {
         int offset = (dto.getCurrentPage() - 1) * dto.getPageSize();  // 페이징 offset 계산
         int pageSize = dto.getPageSize();
 
-        return contestListMapper.getContestList(offset, pageSize);
+        return contestListMapper.getContestList(offset, pageSize, orderType);
     }
 
     public int getTotalCount(){// 전체 게시물 수를 조회하는 메서드

--- a/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
@@ -5,6 +5,7 @@ import com.DOH.DOH.dto.list.ContestListDTO;
 import com.DOH.DOH.dto.list.PagingDTO;
 import com.DOH.DOH.mapper.list.ContestListMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -19,46 +20,45 @@ import java.util.Hashtable;
 public class ContestListServiceImpl implements ContestListService {
 
     @Autowired
-    private SqlSession sqlSession;
-
-    @Autowired
     ContestListMapper contestListMapper;
 
     @Override
     public ArrayList<ContestListDTO> getContestList(PagingDTO dto) {
-//        ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
         int offset = (dto.getCurrentPage() - 1) * dto.getPageSize();  // 페이징 offset 계산
         int pageSize = dto.getPageSize();
 
         return contestListMapper.getContestList(offset, pageSize);
     }
 
-    public int getTotalCount(){
-//        ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
+    public int getTotalCount(){// 전체 게시물 수를 조회하는 메서드
         return contestListMapper.getTotalCount();
-    } // 전체 게시물 수를 조회하는 메서드
+    }
 
     public void hitUp(int contestId) {//조회수 증가 메서드
         contestListMapper.hitUp(contestId);
     }
 
     @Override
-//    public boolean scrap(String userEmail, int contestId) {
-    public boolean scrap(@RequestParam HashMap<String, String> param) {
-//        boolean scrap = contestListMapper.searchScrap(userEmail, contestId);
-        boolean scrap = contestListMapper.searchScrap(param);
+    public ArrayList<Integer> getScrapList(String userEmail){
 
-        if(!scrap){
-//            contestListMapper.addScrap(userEmail, contestId);
-            contestListMapper.addScrap(param);
+        return contestListMapper.getScrapList(userEmail);
+    }
+
+    @Override
+    public int scrap(String userEmail, int contestId) {
+        int count = contestListMapper.searchScrap(userEmail, contestId);
+        int result = 0;
+
+        if(count == 0){
+            contestListMapper.addScrap(userEmail, contestId);
         }else {
-            contestListMapper.deleteScrap(param);
+            contestListMapper.deleteScrap(userEmail,contestId);
+            result = 1;
         }
-        return scrap;
+        return result;
     }
 
     public void saveContestApply(ApplyDTO dto){
-      // ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
         contestListMapper.saveContestApply(dto);
     }
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
@@ -8,8 +8,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.ibatis.session.SqlSession;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Hashtable;
 
 @Slf4j
 @Service("ContestListService")
@@ -32,16 +35,30 @@ public class ContestListServiceImpl implements ContestListService {
 
     public int getTotalCount(){
 //        ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
-
         return contestListMapper.getTotalCount();
     } // 전체 게시물 수를 조회하는 메서드
+
+    public void hitUp(int contestId) {//조회수 증가 메서드
+        contestListMapper.hitUp(contestId);
+    }
+
+    @Override
+//    public boolean scrap(String userEmail, int contestId) {
+    public boolean scrap(@RequestParam HashMap<String, String> param) {
+//        boolean scrap = contestListMapper.searchScrap(userEmail, contestId);
+        boolean scrap = contestListMapper.searchScrap(param);
+
+        if(!scrap){
+//            contestListMapper.addScrap(userEmail, contestId);
+            contestListMapper.addScrap(param);
+        }else {
+            contestListMapper.deleteScrap(param);
+        }
+        return scrap;
+    }
 
     public void saveContestApply(ApplyDTO dto){
       // ContestListMapper contestListMapper = sqlSession.getMapper(ContestListMapper.class);
         contestListMapper.saveContestApply(dto);
-    }
-
-    public void hitUp(int contestId) {//조회수 증가 메서드
-        contestListMapper.hitUp(contestId);
     }
 }

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -12,20 +12,20 @@
                 (datediff(conEndDate, now())) as endDate, conCompanyName
             FROM contest_Upload
             WHERE datediff(conEndDate, now()) >= 0
-<!--        <choose>-->
-<!--            <when test="orderType == 'price'">&lt;!&ndash;총 상금 순&ndash;&gt;-->
-<!--                order by totalPricee desc-->
-<!--            </when>-->
-<!--            <when test="orderType == 'latest'">&lt;!&ndash;마감임박순&ndash;&gt;-->
-<!--                order by endDate asc-->
-<!--            </when>-->
-<!--            <when test="orderType == 'hit'">&lt;!&ndash;조회순&ndash;&gt;-->
-<!--                order by conHit desc-->
-<!--            </when>-->
-<!--            <otherwise>&lt;!&ndash;기본 값 : 최신순&ndash;&gt;-->
-<!--                order by rownum asc-->
-<!--            </otherwise>-->
-<!--        </choose>-->
+        <choose>
+            <when test="orderType == 'price'"><!--총 상금 순-->
+                order by totalPricee desc
+            </when>
+            <when test="orderType == 'latest'"><!--마감임박순-->
+                order by endDate asc
+            </when>
+            <when test="orderType == 'hit'"><!--조회순-->
+                order by conHit desc
+            </when>
+            <otherwise><!--기본 값 : 최신순-->
+                order by rownum asc
+            </otherwise>
+        </choose>
             limit #{offset} , #{pageSize}
     </select>
 

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -7,14 +7,14 @@
     <select id="getContestList" resultType="com.DOH.DOH.dto.list.ContestListDTO">
         SELECT row_number() over(order by id desc) as rownum, id, conType, conTitle,
                 (conFirstPrice * conFirstPeople + conSecondPrice * conSecondPeople
-                + conThirdPrice * conThirdPeople) as totalPrice,
+                + conThirdPrice * conThirdPeople) as totalPrice,conHit,
                 date_format(conEndDate, '%y.%m.%d') as conEndDate,
                 (datediff(conEndDate, now())) as endDate, conCompanyName
             FROM contest_Upload
             WHERE datediff(conEndDate, now()) >= 0
         <choose>
             <when test="orderType == 'price'"><!--총 상금 순-->
-                order by totalPricee desc
+                order by totalPrice desc
             </when>
             <when test="orderType == 'latest'"><!--마감임박순-->
                 order by endDate asc

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -38,21 +38,29 @@
         values(#{conNum}, #{userNum}, #{applyTitle}, #{applyContent}, curdate())
     </insert>
 
+<!--    조회수 증가-->
     <update id="hitUp">
         update contest_Upload set conHit = ifnull(conHit, 0) +1 where id = #{contestId}
     </update>
 
+<!--    기존 관심 공모전 목록 정보를 가져옴-->
+    <select id="getScrapList" resultType="int">
+        select conNum from scrap_contest where userEmail = "${userEmail}"
+    </select>
 
-    <select id="searchScrap" resultType="boolean">
-        select * from scrap_contest where userEmail = ${userEmail}
+<!--    관심 공모전 등록 여부 확인-->
+    <select id="searchScrap" resultType="int">
+        select count(*) from scrap_contest where userEmail = "${userEmail}"
                 and conNum = ${contestId}
     </select>
 
+<!--    관심 공모전 등록-->
     <insert id="addScrap">
-        insert into scrap_contest values(${userEmail}, ${contestId})
+        insert into scrap_contest(userEmail, conNum) values("${userEmail}", ${contestId})
     </insert>
 
+<!--    관심 공모전 삭제-->
     <delete id="deleteScrap">
-        delete from scrap_contest where userEmail = ${userEmail} and conNum = ${contestId}
+        delete from scrap_contest where userEmail = "${userEmail}" and conNum = ${contestId}
     </delete>
 </mapper>

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -41,4 +41,18 @@
     <update id="hitUp">
         update contest_Upload set conHit = ifnull(conHit, 0) +1 where id = #{contestId}
     </update>
+
+
+    <select id="searchScrap" resultType="boolean">
+        select * from scrap_contest where userEmail = ${userEmail}
+                and conNum = ${contestId}
+    </select>
+
+    <insert id="addScrap">
+        insert into scrap_contest values(${userEmail}, ${contestId})
+    </insert>
+
+    <delete id="deleteScrap">
+        delete from scrap_contest where userEmail = ${userEmail} and conNum = ${contestId}
+    </delete>
 </mapper>

--- a/src/main/resources/static/css/list/contestList.css
+++ b/src/main/resources/static/css/list/contestList.css
@@ -88,7 +88,6 @@ section
     border-radius: 6px;
     border: 1px solid var(--line-gray);
     font-size: var(--font-size-14);
-    font-weight: 600;
     padding: 5px 11px;
     box-sizing: border-box;   
 }

--- a/src/main/resources/static/css/list/contestList.css
+++ b/src/main/resources/static/css/list/contestList.css
@@ -143,6 +143,11 @@ section
     color: var(--line-gray);
 }
 
+.fa-heart.active
+{
+    color: var(--main-color);
+}
+
 .listArea h5
 {
     font-size: var(--font-size-16);

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -6,8 +6,6 @@ $(document).ready(function() {
 
 
 function hitUp(e) {
-    console.log("test");
-
     var id = $(e).siblings("#contestId").val();
     console.log(id);
 
@@ -25,7 +23,6 @@ function hitUp(e) {
 }
 
     function order(){
-        alert("test03");
         var orderType = $(".orderWrap .orderType").val();
         console.log("this ->" +orderType);
 
@@ -47,7 +44,6 @@ function hitUp(e) {
     }
 
     function order_page(page){
-        alert("test04");
         var orderType = $(".orderWrap .orderType").val();
         console.log("this ->" +orderType);
 
@@ -70,7 +66,6 @@ function hitUp(e) {
 
  // fa-heart 아이콘 클릭 이벤트
     function scrap(e) {
-        alert("test02");
         event.stopPropagation(); // 이벤트 버블링 방지, 상위 요소로의 이벤트 전달 차단
         event.preventDefault();  // a 태그의 기본 동작(페이지 이동)을 막음
 

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -1,6 +1,4 @@
 $(document).ready(function() {
-    var email = "${userEmail}";  // 서버에서 전달되는 변수라고 가정
-    console.log("session 정보 확인: " + email);
 
     // fa-heart 아이콘 클릭 이벤트
     $(".listArea .fa-heart").click(function(e) {
@@ -9,6 +7,7 @@ $(document).ready(function() {
 
         console.log("fa-heart 클릭!");
 
+        var thisHeart = $(this);
         // 클릭한 fa-heart 아이콘 근처의 input 태그에서 contestId 값을 가져옴
         var id = $(this).closest(".listValue").find("#contestId").val();
         console.log("콘테스트 ID: " + id);
@@ -21,12 +20,16 @@ $(document).ready(function() {
             success: function(result) {
 //                console.log('좋아요 반영 완료');
                 console.log('반영 완료');
-                if(!result){
+                if(result == 0){
                     alert("해당 콘테스트를 스크랩 했습니다.");
-                    $(this).addClass("active");
-                }else{
+                    thisHeart.addClass("active");
+//                    $("#heart"+id).addClass("active");
+                }else if(result == 1){
                     alert("해당 콘테스트가 스크랩 목록에서 삭제되었습니다.");
-                    $(this).removeClass("active");
+                    thisHeart.removeClass("active");
+//                    $("#heart"+id).removeClass("active");
+                }else{
+                    alert("스크랩 기능을 이용하시려면 로그인해 주세요.");
                 }
             },
             error: function(boolean) {
@@ -51,7 +54,6 @@ function hitUp(e) {
         success: function() {
             // 조회수 증가 성공 시 페이지 이동
             console.log('조회수 증가 완료');
-//            location.href = '/contest/view?contestId=' + id;  // 페이지 이동
         },
         error: function(error) {
             // 조회수 증가 실패 시 에러 처리

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -1,22 +1,61 @@
+$(document).ready(function() {
+    var email = "${userEmail}";  // 서버에서 전달되는 변수라고 가정
+    console.log("session 정보 확인: " + email);
+
+    // fa-heart 아이콘 클릭 이벤트
+    $(".listArea .fa-heart").click(function(e) {
+        e.stopPropagation(); // 이벤트 버블링 방지, 상위 요소로의 이벤트 전달 차단
+        e.preventDefault();  // a 태그의 기본 동작(페이지 이동)을 막음
+
+        console.log("fa-heart 클릭!");
+
+        // 클릭한 fa-heart 아이콘 근처의 input 태그에서 contestId 값을 가져옴
+        var id = $(this).closest(".listValue").find("#contestId").val();
+        console.log("콘테스트 ID: " + id);
+
+        // 서버로 Ajax 요청을 보냄
+        $.ajax({
+            url: '/contest/scrap', // 서버의 hitUp 컨트롤러 URL
+            type: 'POST',
+            data: { contestId: id },
+            success: function(result) {
+//                console.log('좋아요 반영 완료');
+                console.log('반영 완료');
+                if(!result){
+                    alert("해당 콘테스트를 스크랩 했습니다.");
+                    $(this).addClass("active");
+                }else{
+                    alert("해당 콘테스트가 스크랩 목록에서 삭제되었습니다.");
+                    $(this).removeClass("active");
+                }
+            },
+            error: function(boolean) {
+                console.log('좋아요 반영 중 오류 발생:', error);
+            }
+        });
+    });
+});
+
 
 function hitUp(e) {
-   console.log("test");
-   var id = $(e).siblings("#contestId").val();
-   console.log(id);
+    console.log("test");
 
-       $.ajax({
-           url: '/contest/hitUp',
-           type: 'POST',
-           data: { contestId: id },
-           success: function() {
-               // 조회수 증가 성공 시 페이지 이동
-               console.log('조회수 증가 완료');
-               location.href = '/contest/view?contestId='+ id;  // 페이지 이동
-           },
-           error: function() {
-               // 조회수 증가 실패 시 에러 처리
-               console.log('조회수 증가 중 오류 발생:', error);
-           }
-       });
+    // `$(e)`를 올바르게 사용, e는 함수에 전달된 DOM 요소라고 가정
+    var id = $(e).siblings("#contestId").val();
+    console.log(id);
 
+    $.ajax({
+        url: '/contest/hitUp',
+        type: 'POST',
+        data: { contestId: id },
+        success: function() {
+            // 조회수 증가 성공 시 페이지 이동
+            console.log('조회수 증가 완료');
+//            location.href = '/contest/view?contestId=' + id;  // 페이지 이동
+        },
+        error: function(error) {
+            // 조회수 증가 실패 시 에러 처리
+            console.log('조회수 증가 중 오류 발생:', error);
+        }
+    });
 }

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -1,48 +1,13 @@
 $(document).ready(function() {
 
-    // fa-heart 아이콘 클릭 이벤트
-    $(".listArea .fa-heart").click(function(e) {
-        e.stopPropagation(); // 이벤트 버블링 방지, 상위 요소로의 이벤트 전달 차단
-        e.preventDefault();  // a 태그의 기본 동작(페이지 이동)을 막음
-
-        console.log("fa-heart 클릭!");
-
-        var thisHeart = $(this);
-        // 클릭한 fa-heart 아이콘 근처의 input 태그에서 contestId 값을 가져옴
-        var id = $(this).closest(".listValue").find("#contestId").val();
-        console.log("콘테스트 ID: " + id);
-
-        $.ajax({
-            url: '/contest/scrap', // 서버의 hitUp 컨트롤러 URL
-            type: 'POST',
-            data: { contestId: id },
-            success: function(result) {
-
-                console.log('반영 완료');
-                if(result == 0){
-                    alert("해당 콘테스트를 스크랩 했습니다.");
-                    thisHeart.addClass("active");
-                }else if(result == 1){
-                    alert("해당 콘테스트가 스크랩 목록에서 삭제되었습니다.");
-                    thisHeart.removeClass("active");
-                }else{
-                    alert("스크랩 기능을 이용하시려면 로그인해 주세요.");
-                }
-            },
-            error: function(boolean) {
-                console.log('좋아요 반영 중 오류 발생:', error);
-            }
-        });
-    });
-
     order();
+
 });
 
 
 function hitUp(e) {
     console.log("test");
 
-    // `$(e)`를 올바르게 사용, e는 함수에 전달된 DOM 요소라고 가정
     var id = $(e).siblings("#contestId").val();
     console.log(id);
 
@@ -60,6 +25,7 @@ function hitUp(e) {
 }
 
     function order(){
+        alert("test03");
         var orderType = $(".orderWrap .orderType").val();
         console.log("this ->" +orderType);
 
@@ -81,6 +47,7 @@ function hitUp(e) {
     }
 
     function order_page(page){
+        alert("test04");
         var orderType = $(".orderWrap .orderType").val();
         console.log("this ->" +orderType);
 
@@ -100,3 +67,39 @@ function hitUp(e) {
             }
         });
     }
+
+ // fa-heart 아이콘 클릭 이벤트
+    function scrap(e) {
+        alert("test02");
+        event.stopPropagation(); // 이벤트 버블링 방지, 상위 요소로의 이벤트 전달 차단
+        event.preventDefault();  // a 태그의 기본 동작(페이지 이동)을 막음
+
+        console.log("fa-heart 클릭!");
+
+        var thisHeart = $(e);
+        // 클릭한 fa-heart 아이콘 근처의 input 태그에서 contestId 값을 가져옴
+        var id = $(e).closest(".listValue").find("#contestId").val();
+        console.log("콘테스트 ID: " + id);
+
+        $.ajax({
+            url: '/contest/scrap', // 서버의 hitUp 컨트롤러 URL
+            type: 'POST',
+            data: { contestId: id },
+            success: function(result) {
+
+                console.log('반영 완료');
+                if(result == 0){
+                    alert("해당 콘테스트를 스크랩 했습니다.");
+                    thisHeart.addClass("active");
+                }else if(result == 1){
+                    alert("해당 콘테스트가 스크랩 목록에서 삭제되었습니다.");
+                    thisHeart.removeClass("active");
+                }else{
+                    alert("스크랩 기능을 이용하시려면 로그인해 주세요.");
+                }
+            },
+            error: function(result) {
+                console.log('좋아요 반영 중 오류 발생:', error);
+            }
+        });
+    };

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -12,22 +12,19 @@ $(document).ready(function() {
         var id = $(this).closest(".listValue").find("#contestId").val();
         console.log("콘테스트 ID: " + id);
 
-        // 서버로 Ajax 요청을 보냄
         $.ajax({
             url: '/contest/scrap', // 서버의 hitUp 컨트롤러 URL
             type: 'POST',
             data: { contestId: id },
             success: function(result) {
-//                console.log('좋아요 반영 완료');
+
                 console.log('반영 완료');
                 if(result == 0){
                     alert("해당 콘테스트를 스크랩 했습니다.");
                     thisHeart.addClass("active");
-//                    $("#heart"+id).addClass("active");
                 }else if(result == 1){
                     alert("해당 콘테스트가 스크랩 목록에서 삭제되었습니다.");
                     thisHeart.removeClass("active");
-//                    $("#heart"+id).removeClass("active");
                 }else{
                     alert("스크랩 기능을 이용하시려면 로그인해 주세요.");
                 }
@@ -52,12 +49,30 @@ function hitUp(e) {
         type: 'POST',
         data: { contestId: id },
         success: function() {
-            // 조회수 증가 성공 시 페이지 이동
             console.log('조회수 증가 완료');
         },
         error: function(error) {
-            // 조회수 증가 실패 시 에러 처리
             console.log('조회수 증가 중 오류 발생:', error);
         }
     });
 }
+
+    function order(){
+        var orderType = $(".orderWrap .orderType").val();
+        console.log("this ->" +orderType);
+
+            $.ajax({
+                url: '/contest/list',
+                type: 'GET',
+                data: { orderType: orderType},
+                success: function(result) {
+                    // 성공적으로 데이터를 받아왔을 때, 페이지 갱신 처리
+                    // result에는 서버에서 전송한 HTML 데이터가 담겨 있다고 가정합니다.
+
+                    // 받아온 데이터를 렌더링할 영역을 찾아서 업데이트
+                    $(".contestWrap").html(result);
+                },
+                error: function() {
+                }
+            });
+    }

--- a/src/main/resources/static/js/list/contestList.js
+++ b/src/main/resources/static/js/list/contestList.js
@@ -34,6 +34,8 @@ $(document).ready(function() {
             }
         });
     });
+
+    order();
 });
 
 
@@ -61,18 +63,40 @@ function hitUp(e) {
         var orderType = $(".orderWrap .orderType").val();
         console.log("this ->" +orderType);
 
-            $.ajax({
-                url: '/contest/list',
-                type: 'GET',
-                data: { orderType: orderType},
-                success: function(result) {
-                    // 성공적으로 데이터를 받아왔을 때, 페이지 갱신 처리
-                    // result에는 서버에서 전송한 HTML 데이터가 담겨 있다고 가정합니다.
+        $.ajax({
+            url: '/contest/list_ajax',//'/contest/list',
+            type: 'GET',
+            data: { orderType: orderType},
+            success: function(result) {
+                // 성공적으로 데이터를 받아왔을 때, 페이지 갱신 처리
+                // result에는 서버에서 전송한 HTML 데이터가 담겨 있다고 가정합니다.
 
-                    // 받아온 데이터를 렌더링할 영역을 찾아서 업데이트
-                    $(".contestWrap").html(result);
-                },
-                error: function() {
-                }
-            });
+                // 받아온 데이터를 렌더링할 영역을 찾아서 업데이트
+                $("#ajax_area").html(result);
+            },
+            error: function() {
+                console.log("에러...");
+            }
+        });
+    }
+
+    function order_page(page){
+        var orderType = $(".orderWrap .orderType").val();
+        console.log("this ->" +orderType);
+
+        $.ajax({
+            url: '/contest/list_ajax',//'/contest/list',
+            type: 'GET',
+            data: { page: page, orderType: orderType},
+            success: function(result) {
+                // 성공적으로 데이터를 받아왔을 때, 페이지 갱신 처리
+                // result에는 서버에서 전송한 HTML 데이터가 담겨 있다고 가정합니다.
+
+                // 받아온 데이터를 렌더링할 영역을 찾아서 업데이트
+                $("#ajax_area").html(result);
+            },
+            error: function() {
+                console.log("에러...");
+            }
+        });
     }

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -27,76 +27,9 @@
                             <option value="hit">조회순</option>
                         </select>
                     </div>
-                    <div class="contestWrap">
-
-                        <div class="listValue" th:each="list : ${contestList}">
-                            <input type="hidden" id="contestId" th:value="${list.id}">
-                            <a href="#" th:href="@{/contest/view(contestId=${list.id})}" th:onclick="hitUp(this)">
-                            <div class="listArea">
-                                <div class="content A">
-                                    <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>
-                                    <div class="industry" th:text="${list.conType}">식품/건강</div>
-                                    <div class="heart">
-                                        <i class="fa-solid fa-heart" th:classappend="${scrapList != null && scrapList.contains(list.id) ? 'active' : ''}"></i>
-                                    </div>
-                                </div>
-                                <h5 th:text="${list.conTitle}">글로벌 한방 브랜드 네이밍 콘테스트</h5>
-                                <div class="content B">
-                                    <div class="contestHost" th:text="${list.conCompanyName}">헬스마켓</div>
-                                    <div class="hit">
-                                        <i class="bi bi-hand-index"></i>
-                                        <span th:text="${list.conHit}">363</span>
-                                    </div>
-                                </div>
-                            </div><!--listArea-->
-                            <div class="listChar">
-                                <div class="priceInfo">
-                                    <div class="infoArea">
-                                        <!-- <div class="infoLeft"> -->
-                                            <div>
-                                                <i class="bi bi-trophy"></i>
-                                            </div>
-                                            <div class="host">총 상금</div>
-                                        <!-- </div> -->
-                                    </div>
-                                    <div class="total P"><span th:text="${list.totalPrice}">30</span> 만원</div>
-                                </div><!--상금 정보 부분-->
-                                <div class="priceInfo">
-                                    <div class="infoArea">
-                                        <!-- <div class="infoLeft"> -->
-                                            <div>
-                                                <i class="bi bi-calendar-week"></i>
-                                            </div>
-                                            <div class="host">남은 기간</div>
-                                        <!-- </div> -->
-                                    </div>
-                                    <div class="total E"><span th:text="${list.endDate}">8</span> 일</div>
-                                </div><!--마감일 부분-->
-                                <div class="priceInfo">
-                                    <div class="lastDate"><span th:text="${list.conEndDate}">24.08.18</span> 마감</div>
-                                </div>
-                            </div><!--listChar-->
-                            </a><!--콘테스트 정보-->
-                        </div><!--listValue-->
-                    </div><!--contestWrap-->
-
-                    <nav aria-label="Page navigation example">
-                        <ul class="pagination justify-content-center">
-                          <li class="page-item" th:if="${pageMaker.prev}">
-                            <a class="page-link" th:href="@{/contest/list(page=${pageMaker.startPage - 1}, orderType=${param.orderType})}" aria-label="Previous">
-                              <span aria-hidden="true">&laquo;</span>
-                            </a>
-                          </li>
-                          <li class="page-item" th:each="i : ${#numbers.sequence(pageMaker.startPage, pageMaker.endPage)}">
-                              <a class="page-link" th:text="${i}" th:href="@{/contest/list(page=${i}, orderType=${param.orderType})}">3</a>
-                          </li>
-                          <li class="page-item" th:if="${pageMaker.next}">
-                            <a class="page-link" th:href="@{/contest/list(page=${pageMaker.endPage + 1}, orderType=${param.orderType})}" aria-label="Next">
-                              <span aria-hidden="true">&raquo;</span>
-                            </a>
-                          </li>
-                        </ul>
-                      </nav>
+                    <div id="ajax_area">
+                        <!-- contestWrap_ajax 호출 -->
+                    </div>
                 </div><!--listWrap-->
             </section><!--section-->
         </div>

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -31,12 +31,13 @@
 
                         <div class="listValue" th:each="list : ${contestList}">
                             <input type="hidden" id="contestId" th:value="${list.id}">
-                            <a href="#" th:onclick="hitUp(this)">
+                            <a href="#" th:href="@{/contest/view(contestId=${list.id})}" th:onclick="hitUp(this)">
                             <div class="listArea">
                                 <div class="content A">
                                     <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>
                                     <div class="industry" th:text="${list.conType}">식품/건강</div>
                                     <div class="heart">
+<!--                                        <i class="fa-solid fa-heart" th:onclick="return false;"></i>-->
                                         <i class="fa-solid fa-heart"></i>
                                     </div>
                                 </div>

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -20,7 +20,7 @@
                 </div><!--listHead-->
                 <div class="listWrap">
                     <div class="orderWrap">
-                        <select name="orderType" id="" class="orderType">
+                        <select name="orderType" id="" class="orderType" th:onchange="order()">
                             <option value="current" selected>최신등록순</option>
                             <option value="latest">마감임박순</option>
                             <option value="price">총 상금순</option>

--- a/src/main/resources/templates/list/contestList.html
+++ b/src/main/resources/templates/list/contestList.html
@@ -37,8 +37,7 @@
                                     <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>
                                     <div class="industry" th:text="${list.conType}">식품/건강</div>
                                     <div class="heart">
-<!--                                        <i class="fa-solid fa-heart" th:onclick="return false;"></i>-->
-                                        <i class="fa-solid fa-heart"></i>
+                                        <i class="fa-solid fa-heart" th:classappend="${scrapList != null && scrapList.contains(list.id) ? 'active' : ''}"></i>
                                     </div>
                                 </div>
                                 <h5 th:text="${list.conTitle}">글로벌 한방 브랜드 네이밍 콘테스트</h5>

--- a/src/main/resources/templates/list/contestWrap_ajax.html
+++ b/src/main/resources/templates/list/contestWrap_ajax.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" >
+<head>
+    <meta charset="UTF-8">
+</head>
+<body>
+<div class="contestWrap">
+    <div class="listValue" th:each="list : ${contestList}">
+        <input type="hidden" id="contestId" th:value="${list.id}">
+        <a href="#" th:href="@{/contest/view(contestId=${list.id})}" th:onclick="hitUp(this)">
+            <div class="listArea">
+                <div class="content A">
+                    <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>
+                    <div class="industry" th:text="${list.conType}">식품/건강</div>
+                    <div class="heart">
+                        <i class="fa-solid fa-heart" th:classappend="${scrapList != null && scrapList.contains(list.id) ? 'active' : ''}"></i>
+                    </div>
+                </div>
+                <h5 th:text="${list.conTitle}">글로벌 한방 브랜드 네이밍 콘테스트</h5>
+                <div class="content B">
+                    <div class="contestHost" th:text="${list.conCompanyName}">헬스마켓</div>
+                    <div class="hit">
+                        <i class="bi bi-hand-index"></i>
+                        <span th:text="${list.conHit}">363</span>
+                    </div>
+                </div>
+            </div><!--listArea-->
+            <div class="listChar">
+                <div class="priceInfo">
+                    <div class="infoArea">
+                        <!-- <div class="infoLeft"> -->
+                        <div>
+                            <i class="bi bi-trophy"></i>
+                        </div>
+                        <div class="host">총 상금</div>
+                        <!-- </div> -->
+                    </div>
+                    <div class="total P"><span th:text="${list.totalPrice}">30</span> 만원</div>
+                </div><!--상금 정보 부분-->
+                <div class="priceInfo">
+                    <div class="infoArea">
+                        <!-- <div class="infoLeft"> -->
+                        <div>
+                            <i class="bi bi-calendar-week"></i>
+                        </div>
+                        <div class="host">남은 기간</div>
+                        <!-- </div> -->
+                    </div>
+                    <div class="total E"><span th:text="${list.endDate}">8</span> 일</div>
+                </div><!--마감일 부분-->
+                <div class="priceInfo">
+                    <div class="lastDate"><span th:text="${list.conEndDate}">24.08.18</span> 마감</div>
+                </div>
+            </div><!--listChar-->
+        </a><!--콘테스트 정보-->
+    </div><!--listValue-->
+</div><!--contestWrap-->
+<nav aria-label="Page navigation example">
+    <ul class="pagination justify-content-center">
+        <li class="page-item" th:if="${pageMaker.prev}">
+            <a class="page-link" th:href="@{/contest/list_ajax(page=${pageMaker.startPage - 1}, orderType=${param.orderType})}" aria-label="Previous">
+                <span aria-hidden="true">&laquo;</span>
+            </a>
+        </li>
+        <li class="page-item" th:each="i : ${#numbers.sequence(pageMaker.startPage, pageMaker.endPage)}">
+            <!-- <a class="page-link" th:text="${i}" th:href="@{/contest/list(page=${i}, orderType=${param.orderType})}">3</a>-->
+            <!-- <a class="page-link" th:text="${i}" th:href="@{/contest/list_ajax(page=${i}, orderType=${param.orderType})}">3</a> -->
+            <a class="page-link" th:text="${i}" th:attr="onclick='order_page(' + ${i} + ')'">3</a>
+        </li>
+        <li class="page-item" th:if="${pageMaker.next}">
+            <!--
+            <a class="page-link" th:href="@{/contest/list_ajax(page=${pageMaker.endPage + 1}, orderType=${param.orderType})}" aria-label="Next">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+            -->
+            <a class="page-link" th:onclick="order_page('${pageMaker.endPage + 1}', '${param.orderType}')" aria-label="Next">
+                <span aria-hidden="true">&raquo;</span>
+            </a>
+        </li>
+    </ul>
+</nav>
+</body>
+</html>

--- a/src/main/resources/templates/list/contestWrap_ajax.html
+++ b/src/main/resources/templates/list/contestWrap_ajax.html
@@ -7,13 +7,14 @@
 <div class="contestWrap">
     <div class="listValue" th:each="list : ${contestList}">
         <input type="hidden" id="contestId" th:value="${list.id}">
-        <a href="#" th:href="@{/contest/view(contestId=${list.id})}" th:onclick="hitUp(this)">
+        <a href="#" th:href="@{/contest/view(contestNum=${list.id})}" th:onclick="hitUp(this)">
+<!--        <a href="#" th:onclick="hitUp(this)">-->
             <div class="listArea">
                 <div class="content A">
                     <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>
                     <div class="industry" th:text="${list.conType}">식품/건강</div>
                     <div class="heart">
-                        <i class="fa-solid fa-heart" th:classappend="${scrapList != null && scrapList.contains(list.id) ? 'active' : ''}"></i>
+                        <i class="fa-solid fa-heart" th:classappend="${scrapList != null && scrapList.contains(list.id) ? 'active' : ''}" th:onclick="scrap(this)"></i>
                     </div>
                 </div>
                 <h5 th:text="${list.conTitle}">글로벌 한방 브랜드 네이밍 콘테스트</h5>


### PR DESCRIPTION
콘테스트 리스트 페이지 정렬 기능 및 스크랩 기능 추가

스크랩 기능 : 회원일 경우 스크랩 기능을 활성화, 비회원일 경우 로그인 alert 발생 처리
정렬 기능 : ajax로 해당 페이지의 번호와 정렬값을 controller로 보내서 처리
![image](https://github.com/user-attachments/assets/366db73c-e873-4b47-a1a7-68ee8da16c17)
![image](https://github.com/user-attachments/assets/021884c8-5ad6-46fe-8f54-3247d59fd628)
![image](https://github.com/user-attachments/assets/5ea2b276-d3a0-40ed-a78c-0dac029af1fd)

![image](https://github.com/user-attachments/assets/667a92ed-015a-48d7-a0c3-ae81763176f4)
