### PR TITLE
120 컨테스트 참여자 조회 및 결과 로직 구현

### DIFF
--- a/src/main/java/com/DOH/DOH/controller/contest/ContestResultController.java
+++ b/src/main/java/com/DOH/DOH/controller/contest/ContestResultController.java
@@ -11,4 +11,9 @@ public class ContestResultController {
     public String test() {
         return "/contest/result";
     }
+
+    @GetMapping("/contest/award")
+    public String contestAward() {
+        return "/contest/contestAward";
+    }
 }

--- a/src/main/java/com/DOH/DOH/controller/contest/ContestResultController.java
+++ b/src/main/java/com/DOH/DOH/controller/contest/ContestResultController.java
@@ -1,19 +1,34 @@
 package com.DOH.DOH.controller.contest;
 
+import com.DOH.DOH.service.contest.ContestUploadService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Slf4j
 @Controller
 public class ContestResultController {
+
+    private final ContestUploadService contestUploadService;
+
+    public ContestResultController(ContestUploadService contestUploadService) {
+        this.contestUploadService = contestUploadService;
+    }
+
+
     @GetMapping("/result")
     public String test() {
         return "/contest/result";
     }
 
     @GetMapping("/contest/award")
-    public String contestAward() {
-        return "/contest/contestAward";
+    public String contestAward(@RequestParam Long contestNum, Model model) {
+
+        model.addAttribute("applicantList",contestUploadService.getContestApplicants(contestNum));
+        return "contest/contestAward";
     }
+
+
 }

--- a/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
+++ b/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
@@ -178,8 +178,7 @@ public class ContestUploadController {
 
         //컨테스트 지원자 목록 가져오기
         List<String>applicantList = contestUploadService.getContestApplicants(contestNum);
-        //model.addAttribute("applicantList",applicantList);
-        log.info("가져온 지원자 목록:{}",applicantList);
+        model.addAttribute("applicantList",applicantList);
 
         return "contest/ContestView";  // 뷰로 이동
     }

--- a/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
+++ b/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
@@ -180,6 +180,9 @@ public class ContestUploadController {
         List<String>applicantList = contestUploadService.getContestApplicants(contestNum);
         model.addAttribute("applicantList",applicantList);
 
+        //컨테스트 작성한 유저 이메일 내보내기
+        model.addAttribute("writer",contestUploadDTO.getUserEmail());
+
         return "contest/ContestView";  // 뷰로 이동
     }
 

--- a/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
+++ b/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
@@ -176,9 +176,13 @@ public class ContestUploadController {
         // 모델에 DTO 객체 자체를 추가
         model.addAttribute("contestUploadDTO", contestUploadDTO);
 
+        //컨테스트 지원자 목록 가져오기
+        List<String>applicantList = contestUploadService.getContestApplicants(contestNum);
+        //model.addAttribute("applicantList",applicantList);
+        log.info("가져온 지원자 목록:{}",applicantList);
+
         return "contest/ContestView";  // 뷰로 이동
     }
-
 
 
 }

--- a/src/main/java/com/DOH/DOH/controller/user/MyPageController.java
+++ b/src/main/java/com/DOH/DOH/controller/user/MyPageController.java
@@ -1,11 +1,13 @@
 package com.DOH.DOH.controller.user;
 
+import com.DOH.DOH.dto.contest.ContestUploadDTO;
 import com.DOH.DOH.dto.user.MyPageDTO;
 import com.DOH.DOH.dto.user.MyPageProfileDTO;
 import com.DOH.DOH.dto.user.PortFolioUploadDTO;
 import com.DOH.DOH.mapper.user.MyPageMapper;
 import com.DOH.DOH.mapper.user.MyPageProfileMapper;
 import com.DOH.DOH.mapper.user.PortFolioUploadMapper;
+import com.DOH.DOH.service.contest.ContestUploadService;
 import com.DOH.DOH.service.user.MyPageProfileService;
 import com.DOH.DOH.service.user.MyPageService;
 import com.DOH.DOH.service.user.PortFolioUploadService;
@@ -41,6 +43,7 @@ public class MyPageController {
     private final String bucketName= "doh-contest-storage";
     private final UserSessionService userSessionService;
     private final MyPageMapper myPageMapper;
+    private final ContestUploadService contestUploadService;
 
     @GetMapping("/users/mypage")
     public String myPage(Long id, Model model, MyPageDTO myPageDTO, MyPageProfileDTO profile) {
@@ -53,6 +56,10 @@ public class MyPageController {
             myPageMapper.insertUserEmail(userEmail);
         }
 
+        //유저 이메일로 생성한 컨테스트 목록 가져오기
+        List<ContestUploadDTO>contestList = contestUploadService.getContestsByUserEmail(userEmail);
+
+        model.addAttribute("contestList",contestList);
         model.addAttribute("myPageDTO", myPageDTO);
         model.addAttribute("profile", profile);
         return "user/MyPage";

--- a/src/main/java/com/DOH/DOH/dto/contest/ContestUploadDTO.java
+++ b/src/main/java/com/DOH/DOH/dto/contest/ContestUploadDTO.java
@@ -37,4 +37,6 @@ public class ContestUploadDTO {
     private int conHit; // 조회수
 
     private String orderNumber; // 주문번호
+
+    private String userEmail; //작성한 유저 이메일
 }

--- a/src/main/java/com/DOH/DOH/mapper/contest/ContestUploadMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/contest/ContestUploadMapper.java
@@ -28,5 +28,8 @@ public interface ContestUploadMapper {
 
     //컨테스트 지원자 목록 가져오기
     List<String>getContestApplicants(Long contestNum);
+
+    //유저 이메일로 생성한 컨테스트 목록 조회하기
+    List<ContestUploadDTO>getContestsByUserEmail(String userEmail);
 }
 

--- a/src/main/java/com/DOH/DOH/mapper/contest/ContestUploadMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/contest/ContestUploadMapper.java
@@ -25,5 +25,8 @@ public interface ContestUploadMapper {
 
     // 오늘 날짜로 콘테스트 카운트 조회
     Integer findContestCountByDate(@Param("formattedDate") String formattedDate);
+
+    //컨테스트 지원자 목록 가져오기
+    List<String>getContestApplicants(Long contestNum);
 }
 

--- a/src/main/java/com/DOH/DOH/service/contest/ContestUploadService.java
+++ b/src/main/java/com/DOH/DOH/service/contest/ContestUploadService.java
@@ -23,4 +23,7 @@ public interface ContestUploadService {
 
     //컨테스트 지원자 목록 가져오기
     List<String>getContestApplicants(Long contestNum);
+
+    //유저 이메일로 생성한 컨테스트 목록 조회하기
+    List<ContestUploadDTO>getContestsByUserEmail(String userEmail);
 }

--- a/src/main/java/com/DOH/DOH/service/contest/ContestUploadService.java
+++ b/src/main/java/com/DOH/DOH/service/contest/ContestUploadService.java
@@ -21,4 +21,6 @@ public interface ContestUploadService {
     // 주문번호 생성
     String generateOrderNumber();
 
+    //컨테스트 지원자 목록 가져오기
+    List<String>getContestApplicants(Long contestNum);
 }

--- a/src/main/java/com/DOH/DOH/service/contest/ContestUploadServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/contest/ContestUploadServiceImpl.java
@@ -67,4 +67,10 @@ public class ContestUploadServiceImpl implements ContestUploadService {
         public List<String>getContestApplicants(Long contestNum){
             return contestUploadMapper.getContestApplicants(contestNum);
         }
+
+    //유저 이메일로 컨테스트 목록 가져오기
+    @Override
+    public List<ContestUploadDTO> getContestsByUserEmail(String userEmail) {
+        return contestUploadMapper.getContestsByUserEmail(userEmail);
+    }
 }

--- a/src/main/java/com/DOH/DOH/service/contest/ContestUploadServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/contest/ContestUploadServiceImpl.java
@@ -62,4 +62,9 @@ public class ContestUploadServiceImpl implements ContestUploadService {
         // 5. 생성된 주문 번호 반환
         return orderNumber;
     }
+
+        //컨테스트 지원자 목록 가져오기
+        public List<String>getContestApplicants(Long contestNum){
+            return contestUploadMapper.getContestApplicants(contestNum);
+        }
 }

--- a/src/main/resources/mapper/contest/ContestUploadMapper.xml
+++ b/src/main/resources/mapper/contest/ContestUploadMapper.xml
@@ -33,4 +33,9 @@
     <select id="getContestApplicants" parameterType="Long" resultType="String">
         select userEmail from DOH.apply_contest where conNum=#{contestNum};
     </select>
+
+    <!--유저 이메일로 생성한 컨테스트 목록 가져오기-->
+    <select id="getContestsByUserEmail" parameterType="String" resultType="com.DOH.DOH.dto.contest.ContestUploadDTO">
+        SELECT * FROM DOH.contest_Upload where userEmail = #{userEmail};
+    </select>
 </mapper>

--- a/src/main/resources/mapper/contest/ContestUploadMapper.xml
+++ b/src/main/resources/mapper/contest/ContestUploadMapper.xml
@@ -29,4 +29,8 @@
         WHERE DATE(createdAt) = #{formattedDate}
     </select>
 
+    <!--컨테스트 지원자 목록 가져오기-->
+    <select id="getContestApplicants" parameterType="Long" resultType="String">
+        select userEmail from DOH.apply_contest where conNum=#{contestNum};
+    </select>
 </mapper>

--- a/src/main/resources/static/css/user/MyPage.css
+++ b/src/main/resources/static/css/user/MyPage.css
@@ -1,151 +1,178 @@
 /* 불필요한 클래스 제거 및 필요없는 주석 삭제 */
 main {
-    display: grid;
-    justify-content: center;
+  display: grid;
+  justify-content: center;
 }
 
 .container {
-    display: grid;
-    width: 1200px;
-    margin-top: 10px;
-    grid-template-columns: 220px 2fr;
-    grid-column-gap: 10px;
-    grid-template-areas:
-        ". button-class"
-        "sidebar main-class"
-        "sidebar management"
-        "sidebar commition";
+  display: grid;
+  width: 1200px;
+  margin-top: 10px;
+  grid-template-columns: 220px 2fr;
+  grid-column-gap: 10px;
+  grid-template-areas:
+    ". button-class"
+    "sidebar main-class"
+    "sidebar management"
+    "sidebar commition";
 }
 
 .underline {
-    text-decoration-line: none;
+  text-decoration-line: none;
 }
 
 .main-class .profilewrite {
-    float: right;
+  float: right;
 }
 
 .profilewrite {
-    text-decoration-line: none;
+  text-decoration-line: none;
 }
 
 .sidebar {
-    grid-area: sidebar;
-    text-align: center;
-    padding: 10px;
-    margin: 10px;
-    height: 400px;
-    list-style-type: none;
-    border: 1px solid whitesmoke;
-    border-radius: 6px;
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.20);
+  grid-area: sidebar;
+  text-align: center;
+  padding: 10px;
+  margin: 10px;
+  height: 400px;
+  list-style-type: none;
+  border: 1px solid whitesmoke;
+  border-radius: 6px;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
 
 .sidebar img {
-    width: 100px;
-    height: 100px;
-    border-radius: 50%;
-    margin-bottom: 10px;
-    justify-content: center;
+  width: 100px;
+  height: 100px;
+  border-radius: 50%;
+  margin-bottom: 10px;
+  justify-content: center;
 }
 
 .sidebar .username {
-    font-size: 18px;
-    font-weight: bold;
-    margin-bottom: 10px;
+  font-size: 18px;
+  font-weight: bold;
+  margin-bottom: 10px;
 }
 
 .sidebar .profile-link {
-    color: #007bff;
-    text-decoration: none;
-    font-size: 14px;
-    margin-bottom: 20px;
-    display: block;
+  color: #007bff;
+  text-decoration: none;
+  font-size: 14px;
+  margin-bottom: 20px;
+  display: block;
 }
 
 .sidebar .edit-profile {
-    background-color: white;
-    padding: 10px 15px;
-    border: 2px solid whitesmoke;
-    text-decoration-line: none;
-    border-radius: 5px;
-    cursor: pointer;
+  background-color: white;
+  padding: 10px 15px;
+  border: 2px solid whitesmoke;
+  text-decoration-line: none;
+  border-radius: 5px;
+  cursor: pointer;
 }
 
 .sidebar .activity {
-    font-size: 14px;
-    color: #555;
-    margin-top: 20px;
+  font-size: 14px;
+  color: #555;
+  margin-top: 20px;
 }
 
 .sidebar .activity span {
-    display: block;
-    margin: 5px 0;
+  display: block;
+  margin: 5px 0;
 }
 
 .sidebar .section-title {
-    font-weight: bold;
-    margin-top: 20px;
-    margin-bottom: 10px;
-    font-size: 16px;
-    color: #333;
+  font-weight: bold;
+  margin-top: 20px;
+  margin-bottom: 10px;
+  font-size: 16px;
+  color: #333;
 }
 
 /* main-class */
 .main-class {
-    grid-area: main-class;
+  grid-area: main-class;
 }
 
 .button-class {
-    display: flex;
-    grid-area: button-class;
-    padding: 10px;
-    justify-content: center;
-    align-items: center;
-    height: 50px;
-    border: 1px solid black;
+  display: flex;
+  grid-area: button-class;
+  padding: 10px;
+  justify-content: center;
+  align-items: center;
+  height: 50px;
+  border: 1px solid black;
 }
 
 .button-class .portfolio {
-    margin-left: auto;
+  margin-left: auto;
 }
 
 .button-class .upload {
-    margin-left: auto;
+  margin-left: auto;
 }
 
 .management {
-    grid-area: management;
+  grid-area: management;
 }
 
 .commition {
-    grid-area: commition;
-    margin-top: 20px;
+  grid-area: commition;
+  margin-top: 20px;
 }
 
 .commition1 {
-    height: 100px;
-    margin: 10px;
-    padding: 10px;
-    overflow: auto;
-    border: 2px solid whitesmoke;
-    box-shadow: 0 5px 10px rgba(0, 0, 0, 0.20);
+  height: 100px;
+  margin: 10px;
+  padding: 10px;
+  overflow: auto;
+  border: 2px solid whitesmoke;
+  box-shadow: 0 5px 10px rgba(0, 0, 0, 0.2);
 }
 
 .management .imagecard {
-    display: flex;
-    border: 1px solid gainsboro;
-    float: left;
-    margin: 5px;
-    box-shadow: 0 5px 15px rgba(0, 0, 0, 0.20);
-    width: 178px;
-    height: 256px;
+  display: flex;
+  border: 1px solid gainsboro;
+  float: left;
+  margin: 5px;
+  box-shadow: 0 5px 15px rgba(0, 0, 0, 0.2);
+  width: 178px;
+  height: 256px;
 }
 
 .management .imagecard:hover {
-    transform: scale(1.05);
+  transform: scale(1.05);
 }
 
 hr {
-    border: 1px solid gainsboro;
+  border: 1px solid gainsboro;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+th,
+td {
+  border: 1px solid #ddd;
+  padding: 8px;
+  text-align: left;
+}
+
+th {
+  background-color: #f2f2f2;
+  font-weight: bold;
+}
+
+.action-btn {
+  background-color: #4caf50;
+  color: white;
+  padding: 5px 10px;
+  text-align: center;
+  text-decoration: none;
+  display: inline-block;
+  border-radius: 4px;
 }

--- a/src/main/resources/templates/contest/ContestView.html
+++ b/src/main/resources/templates/contest/ContestView.html
@@ -35,13 +35,6 @@
                 </div>
             </div>
         </div>
-        <!-- 문의댓글 -->
-        <div class="comments">
-            <div>
-                <textarea id="comments" placeholder="요청 사항에 관련된 사항을 남길 수 있습니다."></textarea>
-                <button type="button">등록</button>
-            </div>
-        </div>
 
         <!-- 참여작 -->
         <div class="work">

--- a/src/main/resources/templates/contest/ContestView.html
+++ b/src/main/resources/templates/contest/ContestView.html
@@ -36,10 +36,13 @@
             </div>
         </div>
 
-        <!-- 참여작 -->
+        <!-- 참여자 -->
         <div class="work">
-            <div>
-                <p>작품 리스트</p>
+            <div th:if="${#lists.isEmpty(applicantList)}">
+                <p>참여자가 없습니다.</p>
+            </div>
+            <div th:each="applicant : ${applicantList}" th:unless="${#lists.isEmpty(applicantList)}">
+                <p><span>👤 </span><span th:text="${applicant}"> 지원자 이름</span></p>
             </div>
         </div>
     </form>

--- a/src/main/resources/templates/contest/ContestView.html
+++ b/src/main/resources/templates/contest/ContestView.html
@@ -18,9 +18,8 @@
             <h1><p>제목 : <span th:text="${contestUploadDTO.conTitle}"></span></p></h1>
             <p>회사명 : <span th:text="${contestUploadDTO.conCompanyName}"></span></p>
             <div class="meta">
-                <span id="request-tab" onclick="showContent('request')">요청 사항</span>
-                <span id="comments-tab" onclick="showContent('comments')">문의 댓글</span>
-                <span id="work-tab" onclick="showContent('work')">작품 목록</span>
+                <span id="request-tab" onclick="showContent('request')">📋 요청 사항</span>
+                <span id="work-tab" onclick="showContent('work')">👥 참여자</span>
             </div>
         </div>
         <!-- 요청사항 -->

--- a/src/main/resources/templates/contest/ContestView.html
+++ b/src/main/resources/templates/contest/ContestView.html
@@ -73,6 +73,12 @@
 
         <p>참여작</p>
         <p>조회수  <span th:text="${contestUploadDTO.conHit}"></span></p>
+
+        <!-- 시상하기 버튼 추가 -->
+        <a th:if="${userEmail == writer}" href="/contest/award" class="button" style="background-color: #28a745; color: white;">
+            시상하기
+        </a>
+
         <a href="/contest/list" class="button">콘테스트 목록으로</a>
         <a href="/api/users/contest/application/terms" class="button">콘테스트 참여하기</a>
     </div>

--- a/src/main/resources/templates/contest/ContestView.html
+++ b/src/main/resources/templates/contest/ContestView.html
@@ -75,7 +75,7 @@
         <p>조회수  <span th:text="${contestUploadDTO.conHit}"></span></p>
 
         <!-- 시상하기 버튼 추가 -->
-        <a th:if="${userEmail == writer}" href="/contest/award" class="button" style="background-color: #28a745; color: white;">
+        <a th:if="${userEmail == writer}" th:href="@{/contest/award(contestNum=${contestUploadDTO.id})}" class="button" style="background-color: #28a745; color: white;">
             시상하기
         </a>
 

--- a/src/main/resources/templates/contest/contestAward.html
+++ b/src/main/resources/templates/contest/contestAward.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <title>시상하기 페이지</title>
+    <link
+            rel="stylesheet"
+            href="https://stackpath.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css"
+    />
+</head>
+<body>
+<div class="container">
+    <h2>수상자 선정</h2>
+    <form action="/contest/award" method="post">
+        <table class="table">
+            <thead>
+            <tr>
+                <th>참여자 이메일</th>
+                <th>순위 선택</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr th:each="participant : ${applicantList}">
+                <td th:text="${participant.userName}">참여자 이메일</td>
+                <td>
+                    <select
+                            name="ranking"
+                            class="form-control"
+                            th:name="ranking_${participant.userId}"
+                    >
+                        <option value="none" selected>순위 선택</option>
+                        <option value="1">1등</option>
+                        <option value="2">2등</option>
+                        <option value="3">3등</option>
+                    </select>
+                </td>
+            </tr>
+            </tbody>
+        </table>
+        <!-- 버튼 섹션 -->
+        <div class="button-section">
+            <button type="submit" class="btn btn-primary">😆 제출하기</button>
+            <button
+                    type="button"
+                    class="btn btn-danger"
+                    onclick="location.href='/contest/no-winner'"
+            >
+                😭 마음에 드는 작품이 없어요
+            </button>
+        </div>
+    </form>
+</div>
+</body>
+</html>

--- a/src/main/resources/templates/contest/contestAward.html
+++ b/src/main/resources/templates/contest/contestAward.html
@@ -19,18 +19,24 @@
             </tr>
             </thead>
             <tbody>
-            <tr th:each="participant : ${applicantList}">
-                <td th:text="${participant.userName}">참여자 이메일</td>
+            <!-- 참여자가 없을 경우 출력 -->
+            <tr th:if="${#lists.isEmpty(applicantList)}">
+                <td colspan="2">참여자가 없습니다.</td>
+            </tr>
+
+            <!-- 참여자가 있을 경우 이메일과 순위 선택 출력 -->
+            <tr th:each="applicant : ${applicantList}">
+                <td th:text="${applicant}">참여자 이메일</td>
                 <td>
                     <select
                             name="ranking"
                             class="form-control"
-                            th:name="ranking_${participant.userId}"
+                            th:name="${applicant}"
                     >
-                        <option value="none" selected>순위 선택</option>
-                        <option value="1">1등</option>
-                        <option value="2">2등</option>
-                        <option value="3">3등</option>
+                    <option value="none" selected>순위 선택</option>
+                    <option value="1">1등</option>
+                    <option value="2">2등</option>
+                    <option value="3">3등</option>
                     </select>
                 </td>
             </tr>

--- a/src/main/resources/templates/user/MyPage.html
+++ b/src/main/resources/templates/user/MyPage.html
@@ -43,16 +43,18 @@
                     <thead>
                     <tr>
                         <th>No.</th>
-                        <th>Title</th>
-                        <th>Date</th>
-                        <th>View Details</th>
+                        <th>제목</th>
+                        <th>모집 기간</th>
+                        <th>조회수</th>
+                        <th>바로 가기</th>
                     </tr>
                     </thead>
                     <tbody>
-                    <tr th:each="contest, iterStat : ${contestList}">
-                        <td th:text="${iterStat.index + 1}">1</td>
-                        <td th:text="${contest.title}">Contest Title</td>
-                        <td th:text="${#dates.format(contest.date, 'yyyy-MM-dd')}">2024-09-25</td>
+                    <tr th:each="contest : ${contestList}">
+                        <td th:text="${contest.id}">1</td>
+                        <td th:text="${contest.conTitle}">Contest Title</td>
+                        <td th:text="${#dates.format(contest.conStartDate, 'yyyy-MM-dd')} + ' - ' + ${#dates.format(contest.conEndDate, 'yyyy-MM-dd')}">2024-09-25 ~ 2024-10-01</td>
+                        <td th:text="${contest.conHit}">Hit</td>
                         <td>
                             <a th:href="@{/contest/detail/{id}(id=${contest.id})}" class="action-btn">바로가기</a>
                         </td>

--- a/src/main/resources/templates/user/MyPage.html
+++ b/src/main/resources/templates/user/MyPage.html
@@ -56,7 +56,7 @@
                         <td th:text="${#dates.format(contest.conStartDate, 'yyyy-MM-dd')} + ' - ' + ${#dates.format(contest.conEndDate, 'yyyy-MM-dd')}">2024-09-25 ~ 2024-10-01</td>
                         <td th:text="${contest.conHit}">Hit</td>
                         <td>
-                            <a th:href="@{/contest/detail/{id}(id=${contest.id})}" class="action-btn">바로가기</a>
+                            <a th:href="@{/contest/view?contestNum={id}(id=${contest.id})}" class="action-btn">바로가기</a>
                         </td>
                     </tr>
                     </tbody>

--- a/src/main/resources/templates/user/MyPage.html
+++ b/src/main/resources/templates/user/MyPage.html
@@ -37,6 +37,30 @@
                 </div>
             </div> <!-- sidebar end -->
             <div class="main-class">
+
+                <h3>내가 개최한 컨테스트 목록보기</h3>
+                <table>
+                    <thead>
+                    <tr>
+                        <th>No.</th>
+                        <th>Title</th>
+                        <th>Date</th>
+                        <th>View Details</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="contest, iterStat : ${contestList}">
+                        <td th:text="${iterStat.index + 1}">1</td>
+                        <td th:text="${contest.title}">Contest Title</td>
+                        <td th:text="${#dates.format(contest.date, 'yyyy-MM-dd')}">2024-09-25</td>
+                        <td>
+                            <a th:href="@{/contest/detail/{id}(id=${contest.id})}" class="action-btn">바로가기</a>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+
+
                 <a href="/users/mypage/profile/write" class="profilewrite" th:if="${profile == null or profile?.profileOneLiner == null}">프로필 작성하러가기</a>
                 <div class="profileOneLiner">
                     <p th:if="${profile != null and profile?.profileOneLiner != null}" th:text="${profile?.profileOneLiner}"></p>
@@ -56,27 +80,28 @@
                     <a href="/users/mypage/upload" class="underline">작품 업로드하기</a>
                 </div>
             </div> <!-- button-class end -->
-            <div class="management">
-                <div><h6>참여한 공모전</h6><hr></div>
-                <div class="imagecard"></div>
-                <div class="imagecard"></div>
-                <div class="imagecard"></div>
-                <div class="imagecard"></div>
-                <div class="imagecard"></div>
+<!--            <div class="management">-->
+<!--                <div><h6>참여한 공모전</h6><hr></div>-->
+<!--                <div class="imagecard"></div>-->
+<!--                <div class="imagecard"></div>-->
+<!--                <div class="imagecard"></div>-->
+<!--                <div class="imagecard"></div>-->
+<!--                <div class="imagecard"></div>-->
 
-            </div>
-            <div class="commition">
-                <div><h6>공모전 의뢰 목록</h6><hr></div>
-                <div class="commition1">
-                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>
-                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>
-                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>
-                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>
-                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>
-                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>
-                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>
-                </div>
-            </div>
+<!--            </div>-->
+<!--            <div class="commition">-->
+<!--                <div><h6>공모전 의뢰 목록</h6><hr></div>-->
+<!--                <div class="commition1">-->
+<!--                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>-->
+<!--                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>-->
+<!--                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>-->
+<!--                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>-->
+<!--                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>-->
+<!--                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>-->
+<!--                    <div>회사를 차리는데 회사 이름 추천 해주세요~</div>-->
+<!--                </div>-->
+<!--            </div>-->
+
 
             </div> <!-- container end -->
         </main>


### PR DESCRIPTION
## 👥 참여자 정보 출력

- 유저의 이메일이 출력됩니다.
- `contest_Upload `테이블의 `id `컬럼과 `apply_contest` 테이블의 `conNum` 컬럼을 연결해야 합니다.
- 개발 중 `conNum`에 `41`이라는 임시 데이터를 넣어 테스트했습니다. 
- 따라서, 콘테스트 참여 로직을 작성할 때, 콘테스트 `id`를 전달받아 해당 id가 `conNum`으로 저장되도록 구현해야 합니다.


❌ **참여자가 없을 때**
<img width="261" alt="스크린샷 2024-09-25 오전 12 24 33" src="https://github.com/user-attachments/assets/ce3d17d7-791c-448d-a61f-1e7d2e9b53f3">

⭕ **참여자가 있을 때**
<img width="264" alt="스크린샷 2024-09-25 오전 12 25 13" src="https://github.com/user-attachments/assets/b904a984-1c64-49b6-9e08-a88e79a89170">



🔥 **삭제 로직**
- `문의 댓글` 삭제


## 📝 마이페이지에 내가 작성한 컨테스트 목록 출력

- 유저가 마이페이지에서 본인이 작성한 컨테스트 목록을 확인할 수 있는 기능을 추가했습니다.
- 바로가기 버튼을 누르면 해당 컨테스트 페이지로 이동합니다.
- 현재 마이페이지에 구현된 UI는 기능 구현 테스트를 위한 임시 UI이며, 최종 코드가 아닙니다. 필요시 디자인을 변경할 수 있습니다.
<img width="1253" alt="스크린샷 2024-09-25 오전 2 47 55" src="https://github.com/user-attachments/assets/3e9630b8-24bf-4700-9930-d8c907bb6052">

## ➕ 시상하기 버튼 추가
<img width="354" alt="스크린샷 2024-09-25 오전 3 08 56" src="https://github.com/user-attachments/assets/15efdbdf-58f4-48aa-813a-8c64c1137893">

- 로그인한 유저와 컨테스트 작성자가 동일할 경우 시상하기 버튼이 출력되도록 구현했습니다.
-  현재 구현된 UI는 기능 구현 테스트를 위한 임시 UI이며, 최종 코드가 아닙니다. 필요시 디자인을 변경할 수 있습니다.

## 🏆 시상하기 페이지
- 위에서 구현한 `시상하기 `버튼 클릭 시 해당 페이지로 이동됩니다.
- 지원자 리스트를 불러와 1, 2, 3등 수상자를 지정할 수 있도록 프론트엔드 구현 완료하였습니다.
- 이후, `시상하기` 브랜치를 새로 생성하여 해당 로직의 백엔드 기능을 구현할 예정입니다.
- 현재 구현된 UI는 기능 구현 테스트를 위한 임시 UI이며, 최종 코드가 아닙니다. 필요시 디자인을 변경할 수 있습니다.
**❌ 참여자가 없을 때**
<img width="1192" alt="스크린샷 2024-09-25 오전 4 02 35" src="https://github.com/user-attachments/assets/bee5af2d-bb36-4567-8e60-bdffe25459e1">

⭕ **참여자가 있을 때**
<img width="1185" alt="스크린샷 2024-09-25 오전 4 03 19" src="https://github.com/user-attachments/assets/5ba785b8-c163-4ee3-880f-1907231a47e4">
