### PR TITLE
콘테스트 응모 로직 전체 점검 및 추가 기능 구현

### DIFF
--- a/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
+++ b/src/main/java/com/DOH/DOH/controller/contest/ContestUploadController.java
@@ -41,7 +41,7 @@ public class ContestUploadController {
     // 1단계: 첫 번째 폼 (회사 정보 등) 보여주기
 //    @GetMapping("/users/contest")
     @GetMapping("/users/contest")
-    public String showContestForm(Model model) {
+    public String showConteLongstForm(Model model) {
         // DB에서 업종 목록 가져오기
         List<String> contestTypes = contestUploadService.getContestTypes();
         model.addAttribute("contestTypes", contestTypes);

--- a/src/main/java/com/DOH/DOH/controller/list/ApplyController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ApplyController.java
@@ -1,6 +1,9 @@
 package com.DOH.DOH.controller.list;
+import com.DOH.DOH.dto.contest.ContestUploadDTO;
 import com.DOH.DOH.dto.list.ApplyDTO;
+import com.DOH.DOH.dto.list.ContestListDTO;
 import com.DOH.DOH.service.common.S3FileUploadService;
+import com.DOH.DOH.service.contest.ContestUploadService;
 import com.DOH.DOH.service.list.ContestListService;
 import com.DOH.DOH.service.list.S3Service;
 import com.DOH.DOH.service.user.UserSessionService;
@@ -32,15 +35,24 @@ public class ApplyController {
         this.s3FileUploadService = s3FileUploadService;
     }
 
+
     //컨테스트 참여 약관동의 페이지 로드
     @GetMapping("/application/terms")
-    public String applictionTerms(HttpSession session){
+    public String applictionTerms(@RequestParam(name = "contestNum")Long id, Model model)
+    {
+        log.info("id test --> "+id);
+
+        ContestListDTO dto = contestListService.contestInfo(id);
+        int count = contestListService.getApplyCount(id);
+
+        model.addAttribute("contestDTO", dto);
+        model.addAttribute("count", count);
         return "list/applicationTerms";
     }
 
     //컨테스트 작성 페이지 로드
     @GetMapping("/application/write")
-    public String applictionWrite(String userEmail, Model model){
+    public String applictionWrite(int id, String userEmail, Model model){
         model.addAttribute("userEmail", userEmail);
         return "list/applicationWrite";
     }

--- a/src/main/java/com/DOH/DOH/controller/list/ApplyController.java
+++ b/src/main/java/com/DOH/DOH/controller/list/ApplyController.java
@@ -18,6 +18,8 @@ import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.security.Principal;
+import java.util.ArrayList;
 import java.util.HashMap;
 
 @Slf4j
@@ -52,8 +54,23 @@ public class ApplyController {
 
     //컨테스트 작성 페이지 로드
     @GetMapping("/application/write")
-    public String applictionWrite(int id, String userEmail, Model model){
-        model.addAttribute("userEmail", userEmail);
+    public String applictionWrite(@RequestParam(name = "contestNum")Long id, Principal principal, Model model){
+        String userEmail = " ";
+
+        if (principal != null) { // principal이 null이 아닌 경우 처리
+            userEmail = principal.getName();
+            log.info("email test - -->"+userEmail);
+            model.addAttribute("userEmail", userEmail);
+        }else{
+            return "user/login";
+        }
+
+        ContestListDTO dto = contestListService.contestInfo(id);
+        int count = contestListService.getApplyCount(id);
+
+        model.addAttribute("contestDTO", dto);
+        model.addAttribute("count", count);
+
         return "list/applicationWrite";
     }
 

--- a/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
+++ b/src/main/java/com/DOH/DOH/mapper/list/ContestListMapper.java
@@ -25,4 +25,7 @@ public interface ContestListMapper {
     void addScrap(@Param("userEmail") String uerEmail,@Param("contestId") int contestId);
     void deleteScrap(@Param("userEmail") String uerEmail,@Param("contestId") int contestId);
 
+    ContestListDTO contestInfo(Long id);
+    int getApplyCount(Long id);
+
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListService.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListService.java
@@ -20,4 +20,7 @@ public interface ContestListService {
     ArrayList<Integer> getScrapList(String userEmail);
     int scrap(String email, int contestId);
     void saveContest(ApplyDTO applyDTO);
+
+    ContestListDTO contestInfo(Long id);
+    int getApplyCount(Long id);
 }

--- a/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
+++ b/src/main/java/com/DOH/DOH/service/list/ContestListServiceImpl.java
@@ -63,4 +63,16 @@ public class ContestListServiceImpl implements ContestListService {
     public void saveContest(ApplyDTO applyDTO) {
         contestListMapper.saveContest(applyDTO);
     }
+
+    @Override
+    public ContestListDTO contestInfo(Long id){
+
+        return contestListMapper.contestInfo(id);
+    }
+
+    @Override
+    public int getApplyCount(Long id){
+
+        return contestListMapper.getApplyCount(id);
+    }
 }

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -34,7 +34,8 @@
     </select>
 
     <insert id="saveContest" parameterType="com.DOH.DOH.dto.list.ApplyDTO">
-        insert into apply_contest(userEmail,applyTitle,applyContent,imageUrl ) values(#{userEmail}, #{applyTitle}, #{applyContent},#{imageUrl})
+        insert into apply_contest(userEmail,applyTitle,applyContent,imageUrl )
+                values(#{userEmail}, #{applyTitle}, #{applyContent},#{imageUrl})
     </insert>
 
 <!--    조회수 증가-->
@@ -53,13 +54,24 @@
                 and conNum = ${contestId}
     </select>
 
-<!--    관심 공모전 등록-->
+<!--    관심 공모전 정보 등록-->
     <insert id="addScrap">
         insert into scrap_contest(userEmail, conNum) values("${userEmail}", ${contestId})
     </insert>
 
-<!--    관심 공모전 삭제-->
+<!--    관심 공모전 정보 삭제-->
     <delete id="deleteScrap">
         delete from scrap_contest where userEmail = "${userEmail}" and conNum = ${contestId}
     </delete>
+
+    <select id="contestInfo" resultType="com.DOH.DOH.dto.list.ContestListDTO">
+        SELECT id, conType, conTitle, (conFirstPrice * conFirstPeople + conSecondPrice * conSecondPeople
+                + conThirdPrice * conThirdPeople) as totalPrice,
+                (datediff(conEndDate, now())) as endDate
+            FROM contest_Upload where id = ${id}
+    </select>
+
+    <select id="getApplyCount" resultType="int">
+        select count(*) from apply_contest where conNum = ${id}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/list/ContestListMapper.xml
+++ b/src/main/resources/mapper/list/ContestListMapper.xml
@@ -34,8 +34,8 @@
     </select>
 
     <insert id="saveContest" parameterType="com.DOH.DOH.dto.list.ApplyDTO">
-        insert into apply_contest(userEmail,applyTitle,applyContent,imageUrl )
-                values(#{userEmail}, #{applyTitle}, #{applyContent},#{imageUrl})
+        insert into apply_contest(conNum, userEmail,applyTitle,applyContent,imageUrl )
+                values(#{conNum}, #{userEmail}, #{applyTitle}, #{applyContent},#{imageUrl})
     </insert>
 
 <!--    조회수 증가-->

--- a/src/main/resources/static/css/list/applicationTerms.css
+++ b/src/main/resources/static/css/list/applicationTerms.css
@@ -1,4 +1,3 @@
-@import url('https://cdn.rawgit.com/moonspam/NanumSquare/master/nanumsquare.css');
 
 :root
 {
@@ -31,11 +30,14 @@ main
 /* 콘테스트 정보 영역 */
 .contestWarap
 {
+    width: 100%;
     height: 114px;
     padding: 15px 35px 15px 35px;
+    box-sizing:border-box;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    margin-bottom: 40px;
 }
 
 .day, .applyInfo
@@ -75,12 +77,19 @@ a
     color: var(--color-black);
     text-decoration-line: none;
 }
+
 .briefing
 {
-    font-size: var(--font-size-20);
-    padding: 15px 20px;
+    font-size: var(--font-size-16);
+    padding: 10px 20px;
     border: 1px solid var(--line-gray);
     border-radius: 6px;
+    &:hover
+    {
+        border: 1px solid var(--color-black);
+        background: var(--color-black);
+        color: var(--color-white);
+    }
 }
 
 /* section */
@@ -182,6 +191,7 @@ section
     width: 92px;
     height: 45px;
     border-radius: 6px;
+    gap : 5px;
     background-color: var(--line-gray);
     cursor: pointer;
     &:hover

--- a/src/main/resources/static/css/list/applicationWrite.css
+++ b/src/main/resources/static/css/list/applicationWrite.css
@@ -75,12 +75,19 @@ a
     color: var(--color-black);
     text-decoration-line: none;
 }
+
 .briefing
 {
-    font-size: var(--font-size-20);
-    padding: 15px 20px;
+    font-size: var(--font-size-16);
+    padding: 10px 20px;
     border: 1px solid var(--line-gray);
     border-radius: 6px;
+    &:hover
+    {
+        border: 1px solid var(--color-black);
+        background: var(--color-black);
+        color: var(--color-white);
+    }
 }
 
 /* 지원 입력 내용 부분 */

--- a/src/main/resources/static/js/list/applicationTerms.js
+++ b/src/main/resources/static/js/list/applicationTerms.js
@@ -1,4 +1,7 @@
-//$(document).ready(function() {
+$(document).ready(function() {
+    Date()
+});//end of document ready
+
     // 아이디어 업로드 체크리스트
     $('#check\\ A').change(function() {
         if($(this).is(':checked')) {

--- a/src/main/resources/static/js/list/applicationTerms.js
+++ b/src/main/resources/static/js/list/applicationTerms.js
@@ -1,6 +1,15 @@
 $(document).ready(function() {
-    Date()
-});//end of document ready
+    let today = new Date();
+
+    let year = today.getFullYear(); // 년도
+    let month = today.getMonth() + 1;  // 월
+    let date = today.getDate();  // 날짜
+
+    let day = year + '년 ' + month + '월 ' + date+ '일 기준';
+//    console.log(day);
+
+    $(".check.date").text(day);
+
 
     // 아이디어 업로드 체크리스트
     $('#check\\ A').change(function() {
@@ -23,9 +32,6 @@ $(document).ready(function() {
     });
 
     $('#check\\ A, #check\\ B, #check\\ C').change(function(){
-        // if($(this).isChecked){
-        //     $('#checkAll').prop('checked', isChecked);
-        // }
         $('#check\\ A, #check\\ B, #check\\ C').change(function() {
             // 하위 항목 체크박스들 중 체크되지 않은 항목이 있는지 확인
             if ($('#check\\ A').is(':checked') && $('#check\\ B').is(':checked') && $('#check\\ C').is(':checked')) {
@@ -53,12 +59,16 @@ $(document).ready(function() {
             $('.popUP.C').slideUp();
         }
     });
-//});//end of document ready
+});//end of document ready
 
 //유효성 검사
 function check() {
-    
-    // var checkAll = document.querySelector("#checkAll");
+    const urlParams = new URLSearchParams(location.search);
+    //현재 페이지의 URL 값을 가져옴
+    const contestNum = urlParams.get('contestNum');
+    //현재 페이지의 URL에서 noticem_num 값을 가져옴
+    console.log(contestNum);
+
     var checkAll = document.querySelector("#checkAll");
     if(!checkAll.checked)
     {
@@ -67,5 +77,5 @@ function check() {
         return false;
      }
 
-     location.href="/api/users/contest/application/write";
+     location.href="/api/users/contest/application/write?contestNum="+contestNum;
  } 

--- a/src/main/resources/static/js/list/applicationWrite.js
+++ b/src/main/resources/static/js/list/applicationWrite.js
@@ -1,4 +1,5 @@
 $(document).ready(function () {
+
     // label을 클릭하면 파일 선택창이 뜨도록 처리
     $(".imageUpload").on("click", function () {
         $("#image").click();
@@ -25,6 +26,7 @@ $(document).ready(function () {
     // 폼 제출 시 선택된 파일을 서버로 전송
     $("form").on("submit", function (e) {
         e.preventDefault(); // 기본 폼 제출 막기
+        var contestNum = document.getElementById("conNum").value;
         var formData = new FormData(this); // 폼 데이터를 객체로 저장
         // AJAX를 이용한 서버로 파일 전송
         $.ajax({
@@ -35,7 +37,7 @@ $(document).ready(function () {
             processData: false,
             success: function (response) {
                 alert("파일이 성공적으로 업로드되었습니다!");
-                //window.location.href = "/추후 변경 요망";
+                window.location.href = "/contest/view?contestNum="+contestNum;
             },
             error: function (error) {
                 alert("업로드 중 오류가 발생했습니다.");

--- a/src/main/resources/templates/contest/ContestView.html
+++ b/src/main/resources/templates/contest/ContestView.html
@@ -79,7 +79,8 @@
         <p>참여작</p>
         <p>조회수  <span th:text="${contestUploadDTO.conHit}"></span></p>
         <a href="/contest/list" class="button">콘테스트 목록으로</a>
-        <a href="/api/users/contest/application/terms" class="button">콘테스트 참여하기</a>
+<!--        <a href="/api/users/contest/application/terms" class="button">콘테스트 참여하기</a>-->
+        <a th:href="@{/api/users/contest/application/terms(contestNum=${contestUploadDTO.id})}" class="button">콘테스트 참여하기</a>
     </div>
 </div>
 

--- a/src/main/resources/templates/list/applicationTerms.html
+++ b/src/main/resources/templates/list/applicationTerms.html
@@ -26,7 +26,7 @@
             <div class="contestWarap">
                 <div class="contestInfo">
                     <div class="day">
-                        <div class="endDate info"><span >8</span>일</div>
+                        <div class="endDate info"><span th:text="${contestDTO.endDate}">8</span>일</div>
                         <div class="type info" th:text="${contestDTO.conType}">공공 기관</div>
                     </div>
                     <div class="contitle" th:text="${contestDTO.conTitle}">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>

--- a/src/main/resources/templates/list/applicationTerms.html
+++ b/src/main/resources/templates/list/applicationTerms.html
@@ -26,16 +26,16 @@
             <div class="contestWarap">
                 <div class="contestInfo">
                     <div class="day">
-                        <div class="endDate info">8일</div>
-                        <div class="type info">공공 기관</div>
+                        <div class="endDate info"><span >8</span>일</div>
+                        <div class="type info" th:text="${contestDTO.conType}">공공 기관</div>
                     </div>
-                    <div class="contitle">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>
+                    <div class="contitle" th:text="${contestDTO.conTitle}">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>
                     <div class="applyInfo">
-                        <div class="info">총 상금 300만원</div>
-                        <div class="info">참여작 <span>9</span>개</div>
+                        <div class="info">총 상금 <span th:text="${contestDTO.totalPrice}">300</span>만원</div>
+                        <div class="info">참여작 <span th:text="${count}">9</span>개</div>
                     </div>
                 </div><!--contestInfo-->
-                <a href="#">
+                <a href="#" th:href="@{/contest/view(contestNum=${contestDTO.id})}">
                     <div class="briefing">브리핑 확인하기</div>
                 </a>
             </div><!--contestWarap-->

--- a/src/main/resources/templates/list/applicationWrite.html
+++ b/src/main/resources/templates/list/applicationWrite.html
@@ -26,16 +26,16 @@
             <div class="contestWarap">
                 <div class="contestInfo">
                     <div class="day">
-                        <div class="endDate info">8일</div>
-                        <div class="type info">공공 기관</div>
+                        <div class="endDate info" th:text="${contestDTO.endDate}">8일</div>
+                        <div class="type info" th:text="${contestDTO.conType}">공공 기관</div>
                     </div>
-                    <div class="contitle">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>
+                    <div class="contitle" th:text="${contestDTO.conTitle}">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>
                     <div class="applyInfo">
-                        <div class="info">총 상금 300만원</div>
-                        <div class="info">참여작 <span>9</span>개</div>
+                        <div class="info">총 상금 <span th:text="${contestDTO.totalPrice}">300</span>만원</div>
+                        <div class="info">참여작 <span th:text="${count}">9</span>개</div>
                     </div>
                 </div><!--contestInfo-->
-                <a href="#">
+                <a href="#" th:href="@{/contest/view(contestNum=${contestDTO.id})}">
                     <div class="briefing">브리핑 확인하기</div>
                 </a>
             </div><!--contestWarap-->
@@ -43,6 +43,7 @@
             
             <section>
                 <form>
+                    <input type="hidden" id="conNum" name="conNum" th:value="${contestDTO.id}">
                     <div class="applyContent">
                         <input type="text" name="applyTitle" placeholder="제목을 입력해주세요." required>
                         <div class="contArea">
@@ -75,9 +76,9 @@
                                 </div>
                             </div>
                         </div><!--applyInput-->
-                        <button type="button" class="temporary">
-                          임시 저장
-                        </button>
+<!--                        <button type="button" class="temporary">-->
+<!--                          임시 저장-->
+<!--                        </button>-->
                         <button type="submit" class="apply">
                           지원하기
                         </button>


### PR DESCRIPTION
콘테스트 상세 페이지에서 콘테스트 참여하기 버튼 클릭시 이동되는 페이지들에 콘테스트 정보 출력
1. 콘테스트 상세 페이지의 해당 버튼의 a 태그에 쿼리스트링으로 값을 넘김
![image](https://github.com/user-attachments/assets/e382637a-4b1f-46e5-8fe0-a3ab7d7503f9)
2. 파라미터를 기반으로 해당 콘테스트의 정보와 참여작 수를 출력함
3. 해당 페이지의 CSS 수정사항 : 브리핑 확인하기 부분의 크기  수정, 동의하기 버튼의 이미지와 텍스트 사이 간격을 키움
4. 약관 동의 기준일을 현재 날짜로 변경 
![image](https://github.com/user-attachments/assets/8d8e9d14-3726-4568-87b2-aee1fbde133a)
5. 해당페이지에서 동의함을 클릭시 이동되는 페이지에서도 값을 출력
6. 임시저장 버튼 주석처리 : 프로젝트 종료로 인함
![image](https://github.com/user-attachments/assets/bbb68495-228b-4089-87bf-7b7085aac67f)

