### PR TITLE
메인페이지 출력값, 지원하기 페이지 남은 기간에 따른 배경 수정

### DIFF
--- a/src/main/resources/static/css/list/applicationTerms.css
+++ b/src/main/resources/static/css/list/applicationTerms.css
@@ -59,7 +59,10 @@ main
     padding: 8px 15px;
     border-radius: 50px;
 }
-
+.endDate.active
+{
+    background: var(--main-color);
+}
 .contitle
 {
     font-size: var(--font-size-20);

--- a/src/main/resources/static/css/list/applicationWrite.css
+++ b/src/main/resources/static/css/list/applicationWrite.css
@@ -57,6 +57,10 @@ main
     padding: 8px 15px;
     border-radius: 50px;
 }
+.endDate.active
+{
+    background: var(--main-color);
+}
 
 .contitle
 {

--- a/src/main/resources/static/css/list/contestList.css
+++ b/src/main/resources/static/css/list/contestList.css
@@ -135,6 +135,11 @@ section
     padding: 3px 7px;
 }
 
+.endDate.active
+{
+    background: var(--main-color);
+}
+
 .heart
 {
     margin-left: auto;

--- a/src/main/resources/static/css/list/main.css
+++ b/src/main/resources/static/css/list/main.css
@@ -92,7 +92,7 @@ main {
 .cardConWarap {
     display: flex;
     justify-content: center;
-    gap: 40px;
+    gap: 30px;
     overflow: hidden;
     width: 100%;
 }

--- a/src/main/resources/static/js/list/main.js
+++ b/src/main/resources/static/js/list/main.js
@@ -33,6 +33,27 @@ document.addEventListener('DOMContentLoaded', function () {
   });
 });
 
+document.addEventListener('DOMContentLoaded', function() {
+    // 첫 번째 글자 수 제한
+    const titles = document.querySelectorAll('.conTitle');
+    titles.forEach(function(title) {
+        const maxLength = 19; // 원하는 글자 수 제한
+        if (title.innerText.length > maxLength) {
+            title.innerText = title.innerText.slice(0, maxLength) + '...';
+        }
+    });
+
+    // 두 번째 글자 수 제한
+    const contexts = document.querySelectorAll('.content .context');
+    contexts.forEach(function(context) {
+        const maxcontext = 15; // 원하는 글자 수 제한
+        if (context.innerText.length > maxcontext) {
+            context.innerText = context.innerText.slice(0, maxcontext) + '...';
+        }
+    });
+});
+
+
 
     function hitUp(e) {
     const href = e.getAttribute('href');

--- a/src/main/resources/templates/list/applicationTerms.html
+++ b/src/main/resources/templates/list/applicationTerms.html
@@ -26,7 +26,7 @@
             <div class="contestWarap">
                 <div class="contestInfo">
                     <div class="day">
-                        <div class="endDate info"><span th:text="${contestDTO.endDate}">8</span>일</div>
+                        <div class="endDate info" th:classappend="${contestDTO.endDate < 4} ? 'active' : ''"><span th:text="${contestDTO.endDate}">8</span>일</div>
                         <div class="type info" th:text="${contestDTO.conType}">공공 기관</div>
                     </div>
                     <div class="contitle" th:text="${contestDTO.conTitle}">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>

--- a/src/main/resources/templates/list/applicationWrite.html
+++ b/src/main/resources/templates/list/applicationWrite.html
@@ -26,7 +26,7 @@
             <div class="contestWarap">
                 <div class="contestInfo">
                     <div class="day">
-                        <div class="endDate info" th:text="${contestDTO.endDate}">8일</div>
+                        <div class="endDate info" th:classappend="${contestDTO.endDate < 4} ? 'active' : ''"><span th:text="${contestDTO.endDate}">8</span>일</div>
                         <div class="type info" th:text="${contestDTO.conType}">공공 기관</div>
                     </div>
                     <div class="contitle" th:text="${contestDTO.conTitle}">[포항문화재단] 포항국제불빛축체 브랜딩 콘테스트</div>

--- a/src/main/resources/templates/list/contestWrap_ajax.html
+++ b/src/main/resources/templates/list/contestWrap_ajax.html
@@ -11,7 +11,7 @@
 <!--        <a href="#" th:onclick="hitUp(this)">-->
             <div class="listArea">
                 <div class="content A">
-                    <div class="endDate"><span th:text="${list.endDate}">8</span>일 남음</div>
+                    <div class="endDate" th:classappend="${list.endDate < 4} ? 'active' : ''"><span th:text="${list.endDate}">8</span>일 남음</div>
                     <div class="industry" th:text="${list.conType}">식품/건강</div>
                     <div class="heart">
                         <i class="fa-solid fa-heart" th:classappend="${scrapList != null && scrapList.contains(list.id) ? 'active' : ''}" th:onclick="scrap(this)"></i>
@@ -47,7 +47,7 @@
                         <div class="host">남은 기간</div>
                         <!-- </div> -->
                     </div>
-                    <div class="total E"><span th:text="${list.endDate}">8</span> 일</div>
+                    <div class="total E" ><span th:text="${list.endDate}">8</span> 일</div>
                 </div><!--마감일 부분-->
                 <div class="priceInfo">
                     <div class="lastDate"><span th:text="${list.conEndDate}">24.08.18</span> 마감</div>

--- a/src/main/resources/templates/list/main.html
+++ b/src/main/resources/templates/list/main.html
@@ -106,7 +106,7 @@
                     </a>
                 </div><!--tabContent-->
                 <div class="tabContent"  id="hit">
-                    <a href="#" th:each="list, listStat : ${priceList}" th:href="@{/contest/view(contestNum=${list.id})}" th:onclick="hitUp(this)">
+                    <a href="#" th:each="list, listStat : ${hitList}" th:href="@{/contest/view(contestNum=${list.id})}" th:onclick="hitUp(this)">
                         <div class="list">
                             <div class="listContent">
                                 <div class="conTitle"><span th:text="${listStat.count}">1</span><span th:text="${list.conTitle}">글로벌 한방 브랜드 네이밍 콘테스트</span></div>


### PR DESCRIPTION
메인페이지 출력값, 지원하기 페이지 남은 기간에 따른 배경 수정
1. 메인페이지의 card 형태의 콘테스트에 제목, 주최자 이름이 길 경우, 디자인이 망가지는 오류가 발생하여 이를 수정하였습니다.
![image](https://github.com/user-attachments/assets/a265920c-22e3-4a40-bcff-8f460080b184)
2. 콘테스트 참여하기 부분에 마감일이 얼마 남지 않은 콘테스트의 경우 마감일의 배경색을 수정하였습니다.
![image](https://github.com/user-attachments/assets/9f9692f4-c072-4c6e-98c7-1f84348a559c)
![image](https://github.com/user-attachments/assets/5c1e635c-84b7-48b4-b913-3145e87ef8a3)

